### PR TITLE
AUI-1953 Unable to have same 'value' for Select with different name/option

### DIFF
--- a/demos/form-builder/index.html
+++ b/demos/form-builder/index.html
@@ -16,6 +16,7 @@
 YUI({ filter:'raw' }).use(
     'aui-form-builder',
     'aui-form-builder-field-choice',
+    'aui-form-builder-field-list',
     'aui-form-builder-field-text',
     'aui-form-builder-field-sentence',
     'aui-form-builder-pages',
@@ -27,9 +28,13 @@ YUI({ filter:'raw' }).use(
                         new Y.LayoutCol({
                             movableContent: false,
                             size: 12,
-                            value: new Y.FormBuilderFieldText({
-                                help: 'Type your full name here',
-                                title: 'What\'s your name?'
+                            value: new Y.FormBuilderFieldList({
+                                fields: [
+                                    new Y.FormBuilderFieldText({
+                                        help: 'Type your full name here',
+                                        title: 'What\'s your name?'
+                                    })
+                                ]
                             })
                         })
                     ]
@@ -38,18 +43,24 @@ YUI({ filter:'raw' }).use(
                     cols: [
                         new Y.LayoutCol({
                             size: 4,
-                            value: new Y.FormBuilderFieldChoice({
-                                help: 'Choose one of the options in the list below',
-                                options: ['Male', 'Female'],
-                                title: 'What\'s your gender?',
-                                type: Y.FormFieldChoice.TYPES.CHECKBOX
+                            value: new Y.FormBuilderFieldList({
+                                fields: [
+                                    new Y.FormBuilderFieldChoice({
+                                        help: 'Choose one of the options in the list below',
+                                        options: ['Male', 'Female'],
+                                        title: 'What\'s your gender?',
+                                        type: Y.FormFieldChoice.TYPES.CHECKBOX
+                                    })
+                                ]
                             })
                         }),
                         new Y.LayoutCol({
-                            size: 4
+                            size: 4,
+                            value: new Y.FormBuilderFieldList()
                         }),
                         new Y.LayoutCol({
-                            size: 4
+                            size: 4,
+                            value: new Y.FormBuilderFieldList()
                         })
                     ]
                 }),
@@ -57,24 +68,28 @@ YUI({ filter:'raw' }).use(
                     cols: [
                         new Y.LayoutCol({
                             size: 12,
-                            value: new Y.FormBuilderFieldSentence({
-                                nestedFields: [
-                                    new Y.FormBuilderFieldText({
-                                        help: 'Type the full name of your school here',
-                                        title: 'Where did you go to school?'
-                                    }),
-                                    new Y.FormBuilderFieldText({
-                                        help: 'Type the full name of your school here',
-                                        title: 'When did you go to that school?'
-                                    }),
-                                    new Y.FormBuilderFieldChoice({
-                                        help: 'Select one of the options below',
-                                        options: ['Computer Science', 'Design'],
-                                        otherOption: true,
-                                        title: 'What is your major?'
+                            value: new Y.FormBuilderFieldList({
+                                fields: [
+                                    new Y.FormBuilderFieldSentence({
+                                        nestedFields: [
+                                            new Y.FormBuilderFieldText({
+                                                help: 'Type the full name of your school here',
+                                                title: 'Where did you go to school?'
+                                            }),
+                                            new Y.FormBuilderFieldText({
+                                                help: 'Type the full name of your school here',
+                                                title: 'When did you go to that school?'
+                                            }),
+                                            new Y.FormBuilderFieldChoice({
+                                                help: 'Select one of the options below',
+                                                options: ['Computer Science', 'Design'],
+                                                otherOption: true,
+                                                title: 'What is your major?'
+                                            })
+                                        ],
+                                        title: 'Regarding education:'
                                     })
-                                ],
-                                title: 'Regarding education:'
+                                ]
                             })
                         })
                     ]
@@ -87,11 +102,19 @@ YUI({ filter:'raw' }).use(
                 new Y.LayoutRow({
                     cols: [
                         new Y.LayoutCol({
-                            movableContent: false,
+                            movableContent: true,
                             size: 12,
-                            value: new Y.FormBuilderFieldText({
-                                help: 'Type your full name here',
-                                title: 'What\'s your name?'
+                            value: new Y.FormBuilderFieldList({
+                                fields: [
+                                    new Y.FormBuilderFieldText({
+                                        help: 'Type your full name here',
+                                        title: 'What\'s your name?'
+                                    }),
+                                    new Y.FormBuilderFieldText({
+                                        help: 'HELP!!!!',
+                                        title: 'Anyone!'
+                                    })
+                                ]
                             })
                         })
                     ]
@@ -107,13 +130,14 @@ YUI({ filter:'raw' }).use(
             },{
                 fieldClass: Y.FormBuilderFieldChoice,
                 icon:'glyphicon glyphicon-font',
-                label: 'Choice'
+                label: 'Choice',
+                unique: true
             },{
                 fieldClass: Y.FormBuilderFieldText,
                 icon:'glyphicon glyphicon-font',
                 label: 'Text'
             }],
-            layouts: [layout, layout2]
+            layouts: [layout2, layout],
         }).render('#formBuilder');
     }
 );

--- a/demos/layout/index.html
+++ b/demos/layout/index.html
@@ -160,6 +160,14 @@
         'aui-form-builder-field-sentence',
         'aui-alert',
         function(Y) {
+            var alert = new Y.Alert({
+                    animated: true,
+                    bodyContent: 'This column can\'t be removed.',
+                    closeable: true,
+                    cssClass: 'alert-warning',
+                    duration: 1
+                });
+
             var Content = Y.Base.create('content', Y.Base, [], {}, {
                 ATTRS: {
                     content: {
@@ -291,19 +299,7 @@
             });
 
             layout.on('layout-col:removalCanceled', function() {
-                var alert = new Y.Alert({
-                    animated: true,
-                    bodyContent: 'This column can\'t be removed.',
-                    closeable: true,
-                    cssClass: 'alert-warning',
-                    destroyOnHide: true,
-                    duration: 1,
-                    render: true
-                });
-
-                setTimeout(function() {
-                    alert.destroy();
-                }, 1500);
+                alert.render();
             });
 
             new Y.LayoutBuilder({

--- a/demos/layout/index.html
+++ b/demos/layout/index.html
@@ -158,6 +158,7 @@
         'aui-form-builder',
         'aui-form-builder-field-text',
         'aui-form-builder-field-sentence',
+        'aui-alert',
         function(Y) {
             var Content = Y.Base.create('content', Y.Base, [], {}, {
                 ATTRS: {
@@ -173,6 +174,7 @@
                         cols: [
                             new Y.LayoutCol({
                                 size: 3,
+                                removable: false,
                                 value: new Y.FormBuilderFieldSentence({
                                     help: 'My Help',
                                     nestedFields: [
@@ -286,6 +288,22 @@
                         ]
                     })
                 ]
+            });
+
+            layout.on('layout-col:removalCanceled', function() {
+                var alert = new Y.Alert({
+                    animated: true,
+                    bodyContent: 'This column can\'t be removed.',
+                    closeable: true,
+                    cssClass: 'alert-warning',
+                    destroyOnHide: true,
+                    duration: 1,
+                    render: true
+                });
+
+                setTimeout(function() {
+                    alert.destroy();
+                }, 1500);
             });
 
             new Y.LayoutBuilder({

--- a/demos/scheduler/index.html
+++ b/demos/scheduler/index.html
@@ -54,6 +54,12 @@
                 startDate: new Date(2014, 6, 23),
                 endDate: new Date(2014, 6, 28),
                 allDay: true
+            },
+            {
+                content: 'Multy Day Event',
+                startDate: new Date(2015, 6, 4),
+                endDate: new Date(2015, 6, 29),
+                allDay: true
             }
         ];
 

--- a/src/aui-autosize/HISTORY.md
+++ b/src/aui-autosize/HISTORY.md
@@ -4,7 +4,7 @@
 
 ## @VERSION@
 
-No registries yet.
+* [AUI-1947](https://issues.liferay.com/browse/AUI-1947) Fix odd behavior on Autosize iframe
 
 ## [3.0.1](https://github.com/liferay/alloy-ui/releases/tag/3.0.1)
 

--- a/src/aui-autosize/js/aui-autosize-iframe.js
+++ b/src/aui-autosize/js/aui-autosize-iframe.js
@@ -404,7 +404,7 @@ A.mix(AutosizeIframe, {
         if (iframeDoc && iframeWin.location.href !== 'about:blank') {
             var docEl = iframeDoc.documentElement;
 
-            var docOffsetHeight = (docEl && docEl.offsetHeight) || 0;
+            var docOffsetHeight = (docEl && Math.max(docEl.offsetHeight, docEl.scrollHeight)) || 0;
 
             var standardsMode = (iframeDoc.compatMode === 'CSS1Compat');
 

--- a/src/aui-base/js/aui-loader.js
+++ b/src/aui-base/js/aui-loader.js
@@ -678,6 +678,7 @@ Y.mix(YUI.Env[Y.version].modules, {
         "requires": [
             "aui-classnamemanager",
             "aui-layout-builder",
+            "aui-modal",
             "base",
             "node-base"
         ],
@@ -925,7 +926,8 @@ Y.mix(YUI.Env[Y.version].modules, {
         "requires": [
             "aui-node-base",
             "base-build"
-        ]
+        ],
+        "skinnable": true
     },
     "aui-layout-builder-resize-col": {
         "requires": [
@@ -1659,4 +1661,4 @@ Y.mix(YUI.Env[Y.version].modules, {
         ]
     }
 });
-YUI.Env[Y.version].md5 = '28c618dc7cbeb232ed7b3961f6548dc6';
+YUI.Env[Y.version].md5 = '0d06435a189f8f16975ebe6e177f7cc0';

--- a/src/aui-base/js/aui-loader.js
+++ b/src/aui-base/js/aui-loader.js
@@ -687,6 +687,7 @@ Y.mix(YUI.Env[Y.version].modules, {
     "aui-form-builder-pages": {
         "requires": [
             "aui-pagination",
+            "aui-tabview",
             "base",
             "event-valuechange",
             "node-base"
@@ -1661,4 +1662,4 @@ Y.mix(YUI.Env[Y.version].modules, {
         ]
     }
 });
-YUI.Env[Y.version].md5 = '0d06435a189f8f16975ebe6e177f7cc0';
+YUI.Env[Y.version].md5 = 'ab923d84628e9d031640eeb9fabb5c3a';

--- a/src/aui-base/js/aui-loader.js
+++ b/src/aui-base/js/aui-loader.js
@@ -596,6 +596,7 @@ Y.mix(YUI.Env[Y.version].modules, {
         "requires": [
             "aui-modal",
             "aui-layout",
+            "aui-form-builder-field-list",
             "aui-form-builder-field-toolbar",
             "aui-form-builder-field-type",
             "aui-form-builder-field-types",
@@ -627,6 +628,15 @@ Y.mix(YUI.Env[Y.version].modules, {
             "aui-form-builder-field-base",
             "aui-form-field-choice"
         ]
+    },
+    "aui-form-builder-field-list": {
+        "requires": [
+            "aui-form-builder-field-type",
+            "aui-form-builder-field-types",
+            "aui-form-builder-layout-builder",
+            "aui-menu"
+        ],
+        "skinnable": true
     },
     "aui-form-builder-field-sentence": {
         "requires": [
@@ -1651,4 +1661,4 @@ Y.mix(YUI.Env[Y.version].modules, {
         ]
     }
 });
-YUI.Env[Y.version].md5 = '7437887ac4a198182ceada26b22ebda3';
+YUI.Env[Y.version].md5 = '6021edeef80d60de5569e83f3b32949b';

--- a/src/aui-base/js/aui-loader.js
+++ b/src/aui-base/js/aui-loader.js
@@ -603,7 +603,6 @@ Y.mix(YUI.Env[Y.version].modules, {
             "aui-form-builder-layout-builder",
             "aui-form-builder-pages",
             "aui-form-builder-settings-modal",
-            "aui-menu",
             "event-focus",
             "event-tap"
         ],
@@ -633,8 +632,7 @@ Y.mix(YUI.Env[Y.version].modules, {
         "requires": [
             "aui-form-builder-field-type",
             "aui-form-builder-field-types",
-            "aui-form-builder-layout-builder",
-            "aui-menu"
+            "aui-form-builder-layout-builder"
         ],
         "skinnable": true
     },
@@ -1661,4 +1659,4 @@ Y.mix(YUI.Env[Y.version].modules, {
         ]
     }
 });
-YUI.Env[Y.version].md5 = '6021edeef80d60de5569e83f3b32949b';
+YUI.Env[Y.version].md5 = '28c618dc7cbeb232ed7b3961f6548dc6';

--- a/src/aui-base/js/aui-loader.json
+++ b/src/aui-base/js/aui-loader.json
@@ -652,6 +652,7 @@
         "requires": [
             "aui-classnamemanager",
             "aui-layout-builder",
+            "aui-modal",
             "base",
             "node-base"
         ],
@@ -899,7 +900,8 @@
         "requires": [
             "aui-node-base",
             "base-build"
-        ]
+        ],
+        "skinnable": true
     },
     "aui-layout-builder-resize-col": {
         "requires": [

--- a/src/aui-base/js/aui-loader.json
+++ b/src/aui-base/js/aui-loader.json
@@ -570,6 +570,7 @@
         "requires": [
             "aui-modal",
             "aui-layout",
+            "aui-form-builder-field-list",
             "aui-form-builder-field-toolbar",
             "aui-form-builder-field-type",
             "aui-form-builder-field-types",
@@ -601,6 +602,15 @@
             "aui-form-builder-field-base",
             "aui-form-field-choice"
         ]
+    },
+    "aui-form-builder-field-list": {
+        "requires": [
+            "aui-form-builder-field-type",
+            "aui-form-builder-field-types",
+            "aui-form-builder-layout-builder",
+            "aui-menu"
+        ],
+        "skinnable": true
     },
     "aui-form-builder-field-sentence": {
         "requires": [

--- a/src/aui-base/js/aui-loader.json
+++ b/src/aui-base/js/aui-loader.json
@@ -661,6 +661,7 @@
     "aui-form-builder-pages": {
         "requires": [
             "aui-pagination",
+            "aui-tabview",
             "base",
             "event-valuechange",
             "node-base"

--- a/src/aui-base/js/aui-loader.json
+++ b/src/aui-base/js/aui-loader.json
@@ -577,7 +577,6 @@
             "aui-form-builder-layout-builder",
             "aui-form-builder-pages",
             "aui-form-builder-settings-modal",
-            "aui-menu",
             "event-focus",
             "event-tap"
         ],
@@ -607,8 +606,7 @@
         "requires": [
             "aui-form-builder-field-type",
             "aui-form-builder-field-types",
-            "aui-form-builder-layout-builder",
-            "aui-menu"
+            "aui-form-builder-layout-builder"
         ],
         "skinnable": true
     },

--- a/src/aui-data-editor/HISTORY.md
+++ b/src/aui-data-editor/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1904](https://issues.liferay.com/browse/AUI-1904) Update textual content on Field Text
 * [AUI-1899](https://issues.liferay.com/browse/AUI-1899) Improve Form Builder visual interface
 * [AUI-1831](https://issues.liferay.com/browse/AUI-1831) Change the way aui-data-editor updates the UI

--- a/src/aui-data-editor/js/aui-data-editor.js
+++ b/src/aui-data-editor/js/aui-data-editor.js
@@ -11,7 +11,7 @@ var CSS_EDITOR = A.getClassName('data', 'editor'),
 
     TPL_EDITOR = '<div class="' + CSS_EDITOR + '">' +
         '<div><label class="' + CSS_EDITOR_LABEL + ' control-label"></label>' +
-        '<label class="' + CSS_EDITOR_REQUIRED_LABEL + ' control-label">REQUIRED</label></div>' +
+        '<label class="' + CSS_EDITOR_REQUIRED_LABEL + ' control-label">{required}</label></div>' +
         '<div class="' + CSS_EDITOR_CONTENT_INNER + '"></div>' +
         '</div>';
 
@@ -34,9 +34,12 @@ A.DataEditor = A.Base.create('data-editor', A.Base, [], {
      * @protected
      */
     initializer: function() {
-        var node = this.get('node');
+        var contentNode,
+            node = this.get('node');
 
-        node.one('.' + CSS_EDITOR_CONTENT_INNER).setHTML(this.TPL_EDITOR_CONTENT);
+        contentNode = A.Lang.sub(this.TPL_EDITOR_CONTENT, this.get('strings'));
+
+        node.one('.' + CSS_EDITOR_CONTENT_INNER).setHTML(contentNode);
 
         this._uiSetLabel(this.get('label'));
         this._uiSetRequired(this.get('required'));
@@ -201,7 +204,13 @@ A.DataEditor = A.Base.create('data-editor', A.Base, [], {
         node: {
             readOnly: true,
             valueFn: function() {
-                return A.Node.create(TPL_EDITOR);
+                var node;
+
+                node = A.Node.create(A.Lang.sub(TPL_EDITOR, {
+                    required: this.get('strings').required
+                }));
+
+                return node;
             }
         },
 
@@ -225,6 +234,19 @@ A.DataEditor = A.Base.create('data-editor', A.Base, [], {
         required: {
             validator: A.Lang.isBoolean,
             value: false
+        },
+
+        /**
+         * Collection of strings used to label elements of the UI.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                required: 'REQUIRED'
+            },
+            writeOnce: true
         },
 
         /**

--- a/src/aui-data-editor/js/aui-data-editor.js
+++ b/src/aui-data-editor/js/aui-data-editor.js
@@ -204,13 +204,9 @@ A.DataEditor = A.Base.create('data-editor', A.Base, [], {
         node: {
             readOnly: true,
             valueFn: function() {
-                var node;
-
-                node = A.Node.create(A.Lang.sub(TPL_EDITOR, {
+                return A.Node.create(A.Lang.sub(TPL_EDITOR, {
                     required: this.get('strings').required
                 }));
-
-                return node;
             }
         },
 

--- a/src/aui-data-editor/js/aui-options-data-editor.js
+++ b/src/aui-data-editor/js/aui-options-data-editor.js
@@ -26,7 +26,7 @@ var CSS_EDITOR = A.getClassName('options', 'data', 'editor'),
 A.OptionsDataEditor = A.Base.create('options-data-editor', A.DataEditor, [], {
     TPL_EDITOR_CONTENT: '<div class="' + CSS_EDITOR + '">' +
         '<div class="' + CSS_EDITOR_OPTIONS + '"></div>' +
-        '<button class="' + CSS_EDITOR_ADD + '">Tap to add an option</button></div>',
+        '<button class="' + CSS_EDITOR_ADD + '">{addOption}</button></div>',
     TPL_EDITOR_OPTION: '<div class="' + CSS_EDITOR_OPTION + '">' +
         '<span class="' + CSS_EDITOR_OPTION_HANDLE + ' glyphicon glyphicon-sort"></span>' +
         '<input class="' + CSS_EDITOR_OPTION_TEXT + ' type="text"" value="{text}"></input>' +
@@ -334,6 +334,20 @@ A.OptionsDataEditor = A.Base.create('options-data-editor', A.DataEditor, [], {
          */
         originalValue: {
             value: []
+        },
+
+        /**
+         * Collection of strings used to label elements of the UI.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                addOption: 'Tap to add an option',
+                required: 'REQUIRED'
+            },
+            writeOnce: true
         }
     }
 });

--- a/src/aui-data-editor/js/aui-options-data-editor.js
+++ b/src/aui-data-editor/js/aui-options-data-editor.js
@@ -346,8 +346,7 @@ A.OptionsDataEditor = A.Base.create('options-data-editor', A.DataEditor, [], {
             value: {
                 addOption: 'Tap to add an option',
                 required: 'REQUIRED'
-            },
-            writeOnce: true
+            }
         }
     }
 });

--- a/src/aui-datatable/js/aui-datatable-base-options-cell-editor.js
+++ b/src/aui-datatable/js/aui-datatable-base-options-cell-editor.js
@@ -222,13 +222,13 @@ BaseOptionsCellEditor = A.Component.create({
             if (editContainer) {
                 var names = editContainer.all('.' + CSS_CELLEDITOR_EDIT_INPUT_NAME);
                 var values = editContainer.all('.' + CSS_CELLEDITOR_EDIT_INPUT_VALUE);
-                var options = {};
+                var options = [];
 
                 names.each(function(inputName, index) {
                     var name = inputName.val();
                     var value = values.item(index).val();
 
-                    options[value] = name;
+                    options.push({'name': name, 'value': value});
                 });
 
                 instance.set('options', options);
@@ -268,7 +268,10 @@ BaseOptionsCellEditor = A.Component.create({
             var optionTpl = instance.OPTION_TEMPLATE;
             var optionWrapperTpl = instance.OPTION_WRAPPER;
 
-            A.each(val, function(oLabel, oValue) {
+            A.each(val, function(option) {
+                var oLabel = option.name;
+                var oValue = option.value;
+
                 var values = {
                     id: A.guid(),
                     label: AEscape.html(oLabel),
@@ -320,8 +323,8 @@ BaseOptionsCellEditor = A.Component.create({
                 })
             );
 
-            A.each(instance.get('options'), function(name, value) {
-                buffer.push(instance._createEditOption(name, value));
+            A.each(instance.get('options'), function(option) {
+                buffer.push(instance._createEditOption(option.name, option.value));
             });
 
             buffer.push(
@@ -504,15 +507,23 @@ BaseOptionsCellEditor = A.Component.create({
          * @protected
          */
         _setOptions: function(val) {
-            var options = {};
+            var options = [];
 
             if (L.isArray(val)) {
-                A.Array.each(val, function(value) {
-                    options[value] = value;
+                A.Array.some(val, function(value) {
+                    if (L.isObject(value)) {
+                        options = val;
+                        return true;
+                    }
+
+                    options.push({'name': value, 'value': value});
+                    return false;
                 });
             }
             else if (L.isObject(val)) {
-                options = val;
+                A.Object.each(val, function(value, key) {
+                    options.push({'name': value, 'value': key});
+                })
             }
 
             return options;

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1926](https://issues.liferay.com/browse/AUI-1926) Change functionality of move rows
 * [AUI-1917](https://issues.liferay.com/browse/AUI-1917) Add option to create Fields between two others Fields on the same column
 * [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1921](https://issues.liferay.com/browse/AUI-1921) A row with one col should be automatically added on last position when the last row have at least two cols

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1921](https://issues.liferay.com/browse/AUI-1921) A row with one col should be automatically added on last position when the last row have at least two cols
 * [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column
 * [AUI-1887](https://issues.liferay.com/browse/AUI-1887) Form builder should have pages, not page breaks
 * [AUI-1904](https://issues.liferay.com/browse/AUI-1904) Update textual content on Field Text

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1931](https://issues.liferay.com/browse/AUI-1931) Add Tabs View mode
 * [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col
 * [AUI-1926](https://issues.liferay.com/browse/AUI-1926) Change functionality of move rows
 * [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -3,7 +3,7 @@
 > Documentation and test modifications are not included in this changelog. For more details, see [full commit history](https://github.com/liferay/alloy-ui/commits/master/src/aui-form-builder).
 
 ## @VERSION@
-
+* [AUI-1930](https://issues.liferay.com/browse/AUI-1930) Change functionality of add cols
 * [AUI-1931](https://issues.liferay.com/browse/AUI-1931) Add Tabs View mode
 * [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col
 * [AUI-1926](https://issues.liferay.com/browse/AUI-1926) Change functionality of move rows

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col
 * [AUI-1926](https://issues.liferay.com/browse/AUI-1926) Change functionality of move rows
 * [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows
 * [AUI-1917](https://issues.liferay.com/browse/AUI-1917) Add option to create Fields between two others Fields on the same column

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -5,6 +5,7 @@
 ## @VERSION@
 
 * [AUI-1926](https://issues.liferay.com/browse/AUI-1926) Change functionality of move rows
+* [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows
 * [AUI-1917](https://issues.liferay.com/browse/AUI-1917) Add option to create Fields between two others Fields on the same column
 * [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1921](https://issues.liferay.com/browse/AUI-1921) A row with one col should be automatically added on last position when the last row have at least two cols

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -3,6 +3,7 @@
 > Documentation and test modifications are not included in this changelog. For more details, see [full commit history](https://github.com/liferay/alloy-ui/commits/master/src/aui-form-builder).
 
 ## @VERSION@
+
 * [AUI-1930](https://issues.liferay.com/browse/AUI-1930) Change functionality of add cols
 * [AUI-1931](https://issues.liferay.com/browse/AUI-1931) Add Tabs View mode
 * [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1917](https://issues.liferay.com/browse/AUI-1917) Add option to create Fields between two others Fields on the same column
 * [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1921](https://issues.liferay.com/browse/AUI-1921) A row with one col should be automatically added on last position when the last row have at least two cols
 * [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column
 * [AUI-1887](https://issues.liferay.com/browse/AUI-1887) Form builder should have pages, not page breaks
 * [AUI-1904](https://issues.liferay.com/browse/AUI-1904) Update textual content on Field Text
 * [AUI-1902](https://issues.liferay.com/browse/AUI-1902) Form Builder fields toolbar buttons should not submit the form (reload the page) after clicked

--- a/src/aui-form-builder/HISTORY.md
+++ b/src/aui-form-builder/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1921](https://issues.liferay.com/browse/AUI-1921) A row with one col should be automatically added on last position when the last row have at least two cols
 * [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column
 * [AUI-1887](https://issues.liferay.com/browse/AUI-1887) Form builder should have pages, not page breaks

--- a/src/aui-form-builder/assets/aui-form-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-core.css
@@ -101,15 +101,13 @@
 }
 
 .form-builder-layout {
-    margin: 0 auto;
-    width: 920px;
+    margin: 0 80px;
 }
 
 .form-builder-pages-header {
     background-color: #FFFFFF;
     margin: 2px auto;
     text-align: center;
-    width: 920px;
 }
 
 .yui3-form-builder-pages {
@@ -122,7 +120,6 @@
     margin: 0 auto;
     position: relative;
     text-align: center;
-    width: 920px;
 }
 
 .form-builder-pages .form-builder-page-controls {
@@ -210,6 +207,6 @@
 
 @media (max-width: 768px) {
     .form-builder-layout {
-        margin: 24px 30px;
+        margin: 24px 20px;
     }
 }

--- a/src/aui-form-builder/assets/aui-form-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-core.css
@@ -110,7 +110,7 @@
     text-align: center;
 }
 
-.yui3-form-builder-pages {
+.form-builder-pages {
     padding-bottom: 5px;
 }
 
@@ -153,7 +153,7 @@
     color: #4fa8ff;
 }
 
-.form-builder-pages-add-page, .form-builder-pages-remove-page {
+.form-builder-pages-add-page, .form-builder-pages-remove-page, .form-builder-switch-view {
     float: right;
     padding: 14px 20px;
     color: #a6d3ff;
@@ -162,12 +162,12 @@
     top: 0;
 }
 
-.form-builder-pages-add-page:hover, .form-builder-pages-remove-page:hover {
+.form-builder-pages-add-page:hover, .form-builder-pages-remove-page:hover, .form-builder-switch-view:hover {
     background-color: #dceeff;
     text-decoration: none;
 }
 
-.form-builder-pages-add-page:focus, .form-builder-pages-remove-page:focus {
+.form-builder-pages-add-page:focus, .form-builder-pages-remove-page:focus, .form-builder-switch-view:focus {
     background-color: transparent;
     text-decoration: none;
 }

--- a/src/aui-form-builder/assets/aui-form-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-core.css
@@ -176,10 +176,6 @@
     margin: 0;
 }
 
-.form-builder-layout .layout-row-container-row + .form-builder-page-break-row-container-row {
-    margin-top: 40pt;
-}
-
 .form-builder-layout .layout-row {
     margin: 0;
 }
@@ -188,13 +184,6 @@
     background-color: #fff;
     min-height: 260px;
     padding: 0;
-}
-
-.form-builder-layout .form-builder-page-break-row-container-row .col {
-    border-radius: 5px 5px 0 0;
-    height: 48pt;
-    line-height: 48pt;
-    min-height: 0;
 }
 
 .form-builder-layout .layout-row .col:last-child {

--- a/src/aui-form-builder/assets/aui-form-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-core.css
@@ -204,79 +204,12 @@
     border-right: none;
 }
 
-.form-builder-empty-col {
-    cursor: pointer;
-    height: 100%;
-    text-align: center;
-}
-
-.form-builder-empty-col-add-button {
-    font: 33px sans-serif;
-    height: 34px;
-    margin-top: -17px;
-    outline: none;
-    position: absolute;
-    text-align: center;
-    top: 50%;
-    width: 100%;
-    z-index: 1;
-}
-
-.form-builder-empty-col-add-button:before {
-    border-top: 2px solid #cce4ff;
-    bottom: 0;
-    content: "";
-    left: 0;
-    margin: 0 auto;
-    position: absolute;
-    right: 0;
-    top: 50%;
-    width: 95%;
-    z-index: -1;
-}
-
-.form-builder-empty-col-add-button .form-builder-empty-col-circle {
-    background: #FFFFFF;
-    border-radius: 50%;
-    border: 1px solid #0078ff;
-    display: inline-block;
-    height: 34px;
-    width: 34px;
-}
-
-.form-builder-empty-col-add-button .form-builder-empty-col-icon {
-    background: #219fff;
-    height: 15px;
-    left: 50%;
-    margin-left: -0.5px;
-    margin-top: -7.5px;
-    position: absolute;
-    top: 50%;
-    width: 1px;
-}
-
-.form-builder-empty-col-add-button .form-builder-empty-col-icon:before {
-    background: #219fff;
-    content: "";
-    height: 1px;
-    left: 50%;
-    margin-left: -7.5px;
-    margin-top: -0.5px;
-    position: absolute;
-    top: 50%;
-    width: 15px;
-}
-
-.form-builder-add-page-break {
-    width: 100%;
+.form-builder-content .layout-builder-add-row {
+    display: none;
 }
 
 @media (max-width: 768px) {
     .form-builder-layout {
         margin: 24px 30px;
     }
-}
-
-.form-builder-content .layout-builder-add-row {
-    display: none;
 }

--- a/src/aui-form-builder/assets/aui-form-builder-field-list-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-field-list-core.css
@@ -1,16 +1,11 @@
-.form-builder-field-list-add-button {
-    height: 100%;
-    text-align: center;
-    margin-bottom: 15px;
-}
-
-.form-builder-field-list-add-button-circle {
-    cursor: pointer;
+.form-builder-field-list-container {
+    padding: 35px 0;
 }
 
 .form-builder-field-list-add-button {
     font: 33px sans-serif;
     height: 34px;
+    margin-bottom: 15px;
     margin-top: -17px;
     outline: none;
     position: relative;
@@ -19,12 +14,24 @@
     z-index: 1;
 }
 
+.form-builder-field-list-add-button-circle {
+    cursor: pointer;
+}
+
+.form-builder-field-list-add-button-content {
+    display: none;
+}
+
+.form-builder-field-list-add-button-visible .form-builder-field-list-add-button-content {
+    display: block;
+}
+
 .form-builder-field-list-empty .form-builder-field-list-add-button {
     position: absolute;
     top: 50%;
 }
 
-.form-builder-field-list-add-button:before {
+.form-builder-field-list-add-button-content:before {
     border-top: 2px solid #cce4ff;
     bottom: 0;
     content: "";

--- a/src/aui-form-builder/assets/aui-form-builder-field-list-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-field-list-core.css
@@ -1,0 +1,76 @@
+.form-builder-field-list-add-button {
+    height: 100%;
+    text-align: center;
+    margin-bottom: 15px;
+}
+
+.form-builder-field-list-add-button-circle {
+    cursor: pointer;
+}
+
+.form-builder-field-list-add-button {
+    font: 33px sans-serif;
+    height: 34px;
+    margin-top: -17px;
+    outline: none;
+    position: relative;
+    text-align: center;
+    width: 100%;
+    z-index: 1;
+}
+
+.form-builder-field-list-empty .form-builder-field-list-add-button {
+    position: absolute;
+    top: 50%;
+}
+
+.form-builder-field-list-add-button:before {
+    border-top: 2px solid #cce4ff;
+    bottom: 0;
+    content: "";
+    left: 0;
+    margin: 0 auto;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 95%;
+    z-index: -1;
+}
+
+.form-builder-field-list-add-button .form-builder-field-list-add-button-circle {
+    background: #FFFFFF;
+    border-radius: 50%;
+    border: 1px solid #0078ff;
+    display: inline-block;
+    height: 34px;
+    width: 34px;
+}
+
+.form-builder-field-list-add-button .form-builder-field-list-add-button-icon {
+    background: #219fff;
+    height: 15px;
+    left: 50%;
+    margin-left: -0.5px;
+    margin-top: -7.5px;
+    position: absolute;
+    top: 50%;
+    width: 1px;
+}
+
+.form-builder-field-list-add-button .form-builder-field-list-add-button-icon:before {
+    background: #219fff;
+    content: "";
+    height: 1px;
+    left: 50%;
+    margin-left: -7.5px;
+    margin-top: -0.5px;
+    position: absolute;
+    top: 50%;
+    width: 15px;
+}
+
+@media (max-width: 768px) {
+    .form-builder-field-list-add-button {
+        margin-top: 0;
+    }
+}

--- a/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
@@ -53,8 +53,8 @@
     border-radius: 50%;
     z-index: 1;
     position: absolute;
-    right: 10px;
-    top: 12px;
+    right: 14px;
+    top: -10px;
 }
 
 .layout-row-container-row {

--- a/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
@@ -1,38 +1,5 @@
-.form-builder-layout-mode .form-builder-header .form-builder-header-back {
-    visibility: visible;
-}
-
-.form-builder-layout-mode .form-builder-header .form-builder-menu {
-    visibility: hidden;
-}
-
-.form-builder-layout-mode .form-builder-empty-col-add-button,
-.form-builder-layout-mode .form-builder-field-content-inner,
-.form-builder-layout-mode .form-builder-field-sentence-help {
-    display: none;
-}
-
-.form-builder-layout-mode .form-builder-field-overlay {
-    background-color: #eee;
-    height: 100%;
-    left: 0;
-    opacity: 0.5;
-    position: absolute;
-    top: 0;
-    width: 100%;
-}
-
-.form-builder-layout-mode .form-builder-field-nested .form-builder-field-overlay {
-    display: none;
-}
-
 .form-builder-content .layout-builder-layout-container {
     margin-bottom: 3px;
-}
-
-.form-builder-layout-mode .form-builder-layout .layout-row-container-row {
-    margin-bottom: 10px;
-    margin-top: 0;
 }
 
 .form-builder-field-move-button {
@@ -47,14 +14,6 @@
     z-index: 1;
 }
 
-.form-builder-layout-mode .layout-builder-move-target {
-    position: relative;
-}
-
-.form-builder-layout-mode .form-builder-field-move-target {
-    display: block;
-    visibility: hidden;
-}
 
 .form-builder-field-move-target {
     background-color: #fff;
@@ -88,4 +47,16 @@
 
 .form-builder-col-moving .form-builder-list-move-target  {
     visibility: hidden;
+}
+
+.layout-builder-move-cut-button.layout-builder-move-cut-row-button {
+    border-radius: 50%;
+    z-index: 1;
+    position: absolute;
+    right: 10px;
+    top: 12px;
+}
+
+.layout-row-container-row {
+    position: relative;
 }

--- a/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
@@ -67,7 +67,7 @@
     z-index: 1;
 }
 
-.form-builder-empty-col .form-builder-field-move-target {
+.form-builder-empty-col-add-button .form-builder-field-move-target {
     margin-left: auto;
     margin-right: auto;
 }

--- a/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-layout-builder-core.css
@@ -85,3 +85,7 @@
 .form-builder-choose-col-move-target .form-builder-field-move-target-invalid {
     visibility: hidden;
 }
+
+.form-builder-col-moving .form-builder-list-move-target  {
+    visibility: hidden;
+}

--- a/src/aui-form-builder/assets/aui-form-builder-settings-modal-core.css
+++ b/src/aui-form-builder/assets/aui-form-builder-settings-modal-core.css
@@ -53,7 +53,6 @@
     width: 123px;
 }
 
-
 .form-builder-field-settings-save {
     background-color: #4fa8ff;
     border-radius: 0px;

--- a/src/aui-form-builder/build.json
+++ b/src/aui-form-builder/build.json
@@ -19,6 +19,12 @@
             ]
         },
 
+		"aui-form-builder-field-list": {
+			"jsfiles": [
+            	"js/aui-form-builder-field-list.js"
+			]
+		},
+
         "aui-form-builder-field-sentence": {
             "jsfiles": [
                 "js/aui-form-builder-field-sentence.js"

--- a/src/aui-form-builder/js/aui-form-builder-field-base.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-base.js
@@ -121,7 +121,8 @@ A.FormBuilderFieldBase.prototype = {
             for (i = 0; i < advancedSettings.length; i++) {
                 this.renderSetting(advancedSettings[i], currentNode);
             }
-        } else {
+        }
+        else {
             this._fieldSettingsPanel.one('.' + CSS_FIELD_SETTINGS_PANEL_ADVANCED).addClass(CSS_HIDE);
             this._fieldSettingsPanel.one('.' + CSS_FIELD_SETTINGS_PANEL_ADVANCED_BUTTON).addClass(CSS_HIDDEN);
         }

--- a/src/aui-form-builder/js/aui-form-builder-field-base.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-base.js
@@ -57,17 +57,17 @@ A.FormBuilderFieldBase.prototype = {
         '</div>',
     TPL_FIELD_MOVE_TARGET: '<button type="button" class="' + CSS_FIELD_MOVE_TARGET +
         ' layout-builder-move-target layout-builder-move-col-target btn btn-default">' +
-        'Paste as subquestion</button>',
+        '{subquestion}</button>',
     TPL_FIELD_SETTINGS_PANEL: '<div class="' + CSS_FIELD_SETTINGS_PANEL + ' clearfix">' +
         '<div class="' + CSS_FIELD_SETTINGS_PANEL_CONTENT + '">' +
         '</div>' +
         '<div class="' + CSS_FIELD_SETTINGS_PANEL_ADVANCED + '">' +
         '<a class="'+ CSS_HIDDEN_XS + ' ' + CSS_FIELD_SETTINGS_PANEL_TOGGLER_ADVANCED +
-        '" href="javascript:void(0)">Advanced options</a>' +
+        '" href="javascript:void(0)">{advancedOptions}</a>' +
         '<div class="' + CSS_FIELD_SETTINGS_PANEL_ADVANCED_CONTENT + '"></div>' +
         '</div>' +
         '<button type="button" class="visible-xs btn btn-default ' + CSS_FIELD_SETTINGS_PANEL_ADVANCED_BUTTON + '">' +
-        '<span class="glyphicon glyphicon-cog"></span>Advanced options</button>' +
+        '<span class="glyphicon glyphicon-cog"></span>{advancedOptions}</button>' +
         '</div>',
     TPL_FIELD_FOOTER_CONTENT: '<div class="' + CSS_FIELD_FOOTER_CONTENT + '"></div>',
 
@@ -81,7 +81,9 @@ A.FormBuilderFieldBase.prototype = {
         var advancedSettings,
             i;
 
-        this._fieldSettingsPanel = A.Node.create(this.TPL_FIELD_SETTINGS_PANEL);
+        this._fieldSettingsPanel = A.Node.create(A.Lang.sub(this.TPL_FIELD_SETTINGS_PANEL, {
+            advancedOptions: this.get('strings').advancedOptions
+        }));
 
         advancedSettings = this._getAdvancedSettings();
 
@@ -265,7 +267,13 @@ A.FormBuilderFieldBase.prototype = {
      * @protected
      */
     _createMoveTarget: function(position) {
-        var targetNode = A.Node.create(this.TPL_FIELD_MOVE_TARGET);
+        var instance = this,
+            targetNode;
+
+        targetNode = A.Node.create(A.Lang.sub(this.TPL_FIELD_MOVE_TARGET, {
+            subquestion: instance.get('strings').subquestion
+        }));
+
         targetNode.setData('nested-field-index', position);
         targetNode.setData('nested-field-parent', this);
 
@@ -390,5 +398,20 @@ A.FormBuilderFieldBase.prototype = {
             nestedFieldsNode.append(nestedField.get('content'));
             nestedFieldsNode.append(instance._createMoveTarget(index + 1));
         });
+    }
+};
+
+A.FormBuilderFieldBase.ATTRS = {
+	/**
+     * Collection of strings used to label elements of the UI.
+     *
+     * @attribute strings
+     * @type {Object}
+     */
+    strings: {
+        value: {
+            subquestion: 'Paste as subquestion',
+            advancedOptions: 'Advanced options'
+        }
     }
 };

--- a/src/aui-form-builder/js/aui-form-builder-field-base.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-base.js
@@ -267,11 +267,10 @@ A.FormBuilderFieldBase.prototype = {
      * @protected
      */
     _createMoveTarget: function(position) {
-        var instance = this,
-            targetNode;
+        var targetNode;
 
         targetNode = A.Node.create(A.Lang.sub(this.TPL_FIELD_MOVE_TARGET, {
-            subquestion: instance.get('strings').subquestion
+            subquestion: this.get('strings').subquestion
         }));
 
         targetNode.setData('nested-field-index', position);
@@ -412,6 +411,7 @@ A.FormBuilderFieldBase.ATTRS = {
         value: {
             subquestion: 'Paste as subquestion',
             advancedOptions: 'Advanced options'
-        }
+        },
+        writeOnce: true
     }
 };

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -37,7 +37,7 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
         '</span>' +
         '<button type="button" class="' + CSS_FIELD_MOVE_TARGET + ' ' + CSS_LIST_MOVE_TARGET +
         ' layout-builder-move-target layout-builder-move-col-target btn btn-default">' +
-        'Paste here</button>' +
+        '{pasteHere}</button>' +
         '</div>' +
         '</div>',
 
@@ -132,7 +132,13 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
                 return A.instanceOf(val, A.Node);
             },
             valueFn: function() {
-                return A.Node.create(this.TPL_FIELD_LIST);
+                var node;
+
+                node = A.Node.create(A.Lang.sub(this.TPL_FIELD_LIST, {
+                    pasteHere: this.get('strings').pasteHere
+                }));
+
+                return node;
             },
             writeOnce: 'initOnly'
         },
@@ -145,6 +151,19 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
          */
         fields: {
             value: []
+        },
+
+        /**
+         * Collection of strings used to label elements of the UI.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                pasteHere: 'Paste here'
+            },
+            writeOnce: true
         }
     }
 });

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -1,0 +1,134 @@
+/**
+ * The Form Builder Field List Component
+ *
+ * @module aui-form-builder-field-list
+ */
+
+var CSS_FIELD_LIST = A.getClassName('form', 'builder', 'field', 'list'),
+    CSS_FIELD_LIST_ADD_BUTTON =
+        A.getClassName('form', 'builder', 'field', 'list', 'add', 'button'),
+    CSS_FIELD_LIST_ADD_BUTTON_CIRCLE =
+        A.getClassName('form', 'builder', 'field', 'list', 'add', 'button', 'circle'),
+    CSS_FIELD_LIST_ADD_BUTTON_ICON =
+        A.getClassName('form', 'builder', 'field', 'list', 'add', 'button', 'icon'),
+    CSS_FIELD_LIST_CONTAINER =
+        A.getClassName('form', 'builder', 'field', 'list', 'container'),
+    CSS_FIELD_LIST_EMPTY = A.getClassName('form', 'builder', 'field', 'list', 'empty'),
+    CSS_FIELD_MOVE_TARGET =
+        A.getClassName('form', 'builder', 'field', 'move', 'target');
+
+/**
+ * A base class for `A.FormBuilderFieldList`.
+ *
+ * @class A.FormBuilderFieldList
+ * @extends A.Widget
+ * @param {Object} config Object literal specifying widget configuration
+ *     properties.
+ * @constructor
+ */
+A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Widget, [], {
+    TPL_FIELD_LIST: '<div class="' + CSS_FIELD_LIST + '">' +
+        '<div class="' + CSS_FIELD_LIST_CONTAINER + '"></div>' +
+        '<div class="' + CSS_FIELD_LIST_ADD_BUTTON + '" tabindex="9">' +
+        '<span class="' + CSS_FIELD_LIST_ADD_BUTTON_CIRCLE + '">' +
+        '<span class="' + CSS_FIELD_LIST_ADD_BUTTON_ICON + '"></span>' +
+        '</span>' +
+        '<button type="button" class="' + CSS_FIELD_MOVE_TARGET +
+        ' layout-builder-move-target layout-builder-move-col-target btn btn-default">' +
+        'Paste here</button>' +
+        '</div>' +
+        '</div>',
+
+    /**
+     * Construction logic executed during the `A.FormBuilderFieldList`
+     * instantiation. Lifecycle.
+     *
+     * @method initializer
+     * @protected
+     */
+    initializer: function() {
+        var contentBox = this.get('contentBox');
+
+        contentBox.append(this.TPL_FIELD_LIST);
+        this._uiSetFields(this.get('fields'));
+
+        this.after('fieldsChange', A.bind(this._afterFieldsChange, this));
+    },
+
+    /**
+     * Adds a new field to the `A.FormBuilderFieldList`.
+     *
+     * @method addField
+     * @param {A.FormBuilderFieldBase} field
+     */
+    addField: function(field) {
+        var fields = this.get('fields');
+
+        fields.push(field);
+        this.set('fields', fields);
+    },
+
+    /**
+     * Removes the given field from the `A.FormBuilderFieldList`.
+     *
+     * @method removeField
+     * @param {A.FormBuilderFieldBase} field
+     */
+    removeField: function(field) {
+        var fields = this.get('fields'),
+            indexOf = fields.indexOf(field);
+
+        fields.splice(indexOf, 1);
+        this.set('fields', fields);
+    },
+
+    /**
+     * Fired after the `fields` attribute is set.
+     *
+     * @method _afterFieldsChange
+     * @protected
+     */
+    _afterFieldsChange: function() {
+        this._uiSetFields(this.get('fields'));
+    },
+
+    /**
+     * Updates the ui according to the value of the `fields` attribute.
+     *
+     * @method _uiSetFields
+     * @param {Array} fields
+     * @protected
+     */
+    _uiSetFields: function(fields) {
+        var contentBox = this.get('contentBox'),
+            container = contentBox.one('.' + CSS_FIELD_LIST_CONTAINER);
+
+        container.empty();
+        A.each(fields, function(field) {
+            container.append(field.get('content'));
+        });
+
+        contentBox.toggleClass(CSS_FIELD_LIST_EMPTY, !fields.length);
+    }
+}, {
+
+    /**
+     * Static property used to define the default attribute
+     * configuration for the `A.FormBuilderFieldList`.
+     *
+     * @property ATTRS
+     * @type Object
+     * @static
+     */
+    ATTRS: {
+        /**
+         * List of field.
+         *
+         * @attribute fields
+         * @type {Array}
+         */
+        fields: {
+            value: []
+        }
+    }
+});

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -132,13 +132,9 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
                 return A.instanceOf(val, A.Node);
             },
             valueFn: function() {
-                var node;
-
-                node = A.Node.create(A.Lang.sub(this.TPL_FIELD_LIST, {
+                return A.Node.create(A.Lang.sub(this.TPL_FIELD_LIST, {
                     pasteHere: this.get('strings').pasteHere
                 }));
-
-                return node;
             },
             writeOnce: 'initOnly'
         },

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -155,12 +155,16 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
     _uiSetFields: function(fields) {
         var content = this.get('content'),
             container = content.one('.' + CSS_FIELD_LIST_CONTAINER),
-            instance = this;
+            addFieldTemplate;
+
+        addFieldTemplate = A.Lang.sub(this.TPL_ADD_FIELD, {
+            pasteHere: this.get('strings').pasteHere
+        });
 
         container.empty();
 
         A.each(fields, function(field) {
-            var addButtonNode = A.Node.create(instance.TPL_ADD_FIELD);
+            var addButtonNode = A.Node.create(addFieldTemplate);
 
             addButtonNode.removeClass(CSS_FIELD_LIST_ADD_BUTTON_VISIBLE);
 
@@ -193,9 +197,10 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
                 return A.instanceOf(val, A.Node);
             },
             valueFn: function() {
-                return A.Node.create(A.Lang.sub(this.TPL_FIELD_LIST, {
+                var addFieldTemplate = A.Lang.sub(this.TPL_ADD_FIELD, {
                     pasteHere: this.get('strings').pasteHere
-                })).append(this.TPL_ADD_FIELD);
+                });
+                return A.Node.create(this.TPL_FIELD_LIST).append(addFieldTemplate);
             },
             writeOnce: 'initOnly'
         },

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -172,6 +172,16 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
             container.append(field.get('content'));
         });
 
+        setTimeout(function() {
+            var col = content.ancestor('.col'),
+                layoutCol;
+
+            if (col) {
+                layoutCol = col.getData('layout-col');
+                layoutCol.set('removable', fields.length === 0);
+            }
+        }, 0);
+
         content.toggleClass(CSS_FIELD_LIST_EMPTY, !fields.length);
     }
 }, {

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -99,7 +99,28 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
      * @protected
      */
     _afterFieldsChange: function() {
-        this._uiSetFields(this.get('fields'));
+        var fields = this.get('fields');
+
+        this._uiSetFields(fields);
+        this._updateRemovableLayoutColProperty();
+    },
+
+    /**
+     * Update removable property for layout cols
+     *
+     * @method _updateRemovableLayoutColProperty
+     * @protected
+     */
+    _updateRemovableLayoutColProperty: function() {
+        var fields = this.get('fields'),
+            content = this.get('content'),
+            col = content.ancestor('.col'),
+            layoutCol;
+
+        if (col) {
+            layoutCol = col.getData('layout-col');
+            layoutCol.set('removable', fields.length === 0);
+        }
     },
 
     /**
@@ -171,16 +192,6 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
             container.append(addButtonNode);
             container.append(field.get('content'));
         });
-
-        setTimeout(function() {
-            var col = content.ancestor('.col'),
-                layoutCol;
-
-            if (col) {
-                layoutCol = col.getData('layout-col');
-                layoutCol.set('removable', fields.length === 0);
-            }
-        }, 0);
 
         content.toggleClass(CSS_FIELD_LIST_EMPTY, !fields.length);
     }

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -15,25 +15,27 @@ var CSS_FIELD_LIST = A.getClassName('form', 'builder', 'field', 'list'),
         A.getClassName('form', 'builder', 'field', 'list', 'container'),
     CSS_FIELD_LIST_EMPTY = A.getClassName('form', 'builder', 'field', 'list', 'empty'),
     CSS_FIELD_MOVE_TARGET =
-        A.getClassName('form', 'builder', 'field', 'move', 'target');
+        A.getClassName('form', 'builder', 'field', 'move', 'target'),
+    CSS_LIST_MOVE_TARGET =
+        A.getClassName('form', 'builder', 'list', 'move', 'target');
 
 /**
  * A base class for `A.FormBuilderFieldList`.
  *
  * @class A.FormBuilderFieldList
- * @extends A.Widget
+ * @extends A.Base
  * @param {Object} config Object literal specifying widget configuration
  *     properties.
  * @constructor
  */
-A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Widget, [], {
+A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
     TPL_FIELD_LIST: '<div class="' + CSS_FIELD_LIST + '">' +
         '<div class="' + CSS_FIELD_LIST_CONTAINER + '"></div>' +
         '<div class="' + CSS_FIELD_LIST_ADD_BUTTON + '" tabindex="9">' +
         '<span class="' + CSS_FIELD_LIST_ADD_BUTTON_CIRCLE + '">' +
         '<span class="' + CSS_FIELD_LIST_ADD_BUTTON_ICON + '"></span>' +
         '</span>' +
-        '<button type="button" class="' + CSS_FIELD_MOVE_TARGET +
+        '<button type="button" class="' + CSS_FIELD_MOVE_TARGET + ' ' + CSS_LIST_MOVE_TARGET +
         ' layout-builder-move-target layout-builder-move-col-target btn btn-default">' +
         'Paste here</button>' +
         '</div>' +
@@ -47,9 +49,6 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Widget, [],
      * @protected
      */
     initializer: function() {
-        var contentBox = this.get('contentBox');
-
-        contentBox.append(this.TPL_FIELD_LIST);
         this._uiSetFields(this.get('fields'));
 
         this.after('fieldsChange', A.bind(this._afterFieldsChange, this));
@@ -100,15 +99,15 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Widget, [],
      * @protected
      */
     _uiSetFields: function(fields) {
-        var contentBox = this.get('contentBox'),
-            container = contentBox.one('.' + CSS_FIELD_LIST_CONTAINER);
+        var content = this.get('content'),
+            container = content.one('.' + CSS_FIELD_LIST_CONTAINER);
 
         container.empty();
         A.each(fields, function(field) {
             container.append(field.get('content'));
         });
 
-        contentBox.toggleClass(CSS_FIELD_LIST_EMPTY, !fields.length);
+        content.toggleClass(CSS_FIELD_LIST_EMPTY, !fields.length);
     }
 }, {
 
@@ -121,6 +120,23 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Widget, [],
      * @static
      */
     ATTRS: {
+
+        /**
+         * Node containing the contents of this field list.
+         *
+         * @attribute content
+         * @type Node
+         */
+        content: {
+            validator: function(val) {
+                return A.instanceOf(val, A.Node);
+            },
+            valueFn: function() {
+                return A.Node.create(this.TPL_FIELD_LIST);
+            },
+            writeOnce: 'initOnly'
+        },
+
         /**
          * List of field.
          *

--- a/src/aui-form-builder/js/aui-form-builder-field-list.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-list.js
@@ -41,10 +41,10 @@ A.FormBuilderFieldList  = A.Base.create('form-builder-field-list', A.Base, [], {
         '<button type="button" class="' + CSS_FIELD_MOVE_TARGET + ' ' + CSS_LIST_MOVE_TARGET +
         ' layout-builder-move-target layout-builder-move-col-target btn btn-default">' +
         '{pasteHere}</button>' +
-        '</div>',
+        '</div></div>',
     TPL_FIELD_LIST: '<div class="' + CSS_FIELD_LIST + '">' +
         '<div class="' + CSS_FIELD_LIST_CONTAINER + '"></div>' +
-        '</div></div>',
+        '</div>',
 
     /**
      * Construction logic executed during the `A.FormBuilderFieldList`

--- a/src/aui-form-builder/js/aui-form-builder-field-toolbar.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-toolbar.js
@@ -54,7 +54,8 @@ A.FormBuilderFieldToolbar = A.Base.create('form-builder-field-toolbar', A.Base, 
             this._eventHandles.push(
                 fieldsContainer.delegate('click', this._onFieldClick, '.' + CSS_FIELD_CONTENT, this)
             );
-        } else {
+        }
+        else {
             this._eventHandles.push(
                 fieldsContainer.delegate('mouseenter', this._onFieldMouseEnter, '.' + CSS_FIELD_CONTENT_TOOLBAR, this),
                 fieldsContainer.delegate('mouseleave', this._onFieldMouseLeave, '.' + CSS_FIELD_CONTENT_TOOLBAR, this)

--- a/src/aui-form-builder/js/aui-form-builder-field-toolbar.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-toolbar.js
@@ -87,7 +87,7 @@ A.FormBuilderFieldToolbar = A.Base.create('form-builder-field-toolbar', A.Base, 
     },
 
     /**
-     * Closes the toolbar
+     * Closes the toolbar.
      *
      * @method close
      */
@@ -96,10 +96,11 @@ A.FormBuilderFieldToolbar = A.Base.create('form-builder-field-toolbar', A.Base, 
     },
 
     /**
-     * Finds one toolbar's item using the selector
+     * Finds one toolbar's item using the selector.
      *
      * @method getItem
      * @param {String} selector
+     * @return {Node}
      */
     getItem: function(selector) {
         return this._toolbar.one(selector);

--- a/src/aui-form-builder/js/aui-form-builder-field-types.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-types.js
@@ -21,7 +21,7 @@ var CSS_FIELD_TYPE = A.getClassName('field', 'type'),
 A.FormBuilderFieldTypes = function() {};
 
 A.FormBuilderFieldTypes.prototype = {
-    TPL_HEADER_LABEL: '<div class="' + CSS_FIELD_TYPES_LABEL + '">Add Field</div>',
+    TPL_HEADER_LABEL: '<div class="' + CSS_FIELD_TYPES_LABEL + '">{addField}</div>',
 
     /**
      * Construction logic executed during the `A.FormBuilderFieldTypes`
@@ -253,6 +253,12 @@ A.FormBuilderFieldTypes.prototype = {
      * @protected
      */
     _createFieldTypesPanel: function() {
+        var headerNode;
+
+        headerNode = A.Lang.sub(this.TPL_HEADER_LABEL, {
+            addField: this.get('strings').addField
+        });
+
         this._fieldTypesPanel = A.Node.create(
             '<div class="clearfix ' + CSS_FIELD_TYPES_LIST + '" role="main" />'
         );
@@ -262,7 +268,7 @@ A.FormBuilderFieldTypes.prototype = {
             centered: true,
             cssClass: 'form-builder-modal',
             draggable: false,
-            headerContent: this.TPL_HEADER_LABEL,
+            headerContent: headerNode,
             modal: true,
             resizable: false,
             toolbars: this._buildFieldTypesToolbarConfig(),
@@ -454,5 +460,18 @@ A.FormBuilderFieldTypes.ATTRS = {
         setter: '_setFieldTypes',
         validator: A.Lang.isArray,
         value: []
-    }
+    },
+
+        /**
+         * Collection of strings used to label elements of the UI.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                addField: 'Add Field'
+            },
+            writeOnce: true
+        }
 };

--- a/src/aui-form-builder/js/aui-form-builder-field-types.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-types.js
@@ -462,16 +462,16 @@ A.FormBuilderFieldTypes.ATTRS = {
         value: []
     },
 
-        /**
-         * Collection of strings used to label elements of the UI.
-         *
-         * @attribute strings
-         * @type {Object}
-         */
-        strings: {
-            value: {
-                addField: 'Add Field'
-            },
-            writeOnce: true
-        }
+    /**
+     * Collection of strings used to label elements of the UI.
+     *
+     * @attribute strings
+     * @type {Object}
+     */
+    strings: {
+        value: {
+            addField: 'Add Field'
+        },
+        writeOnce: true
+    }
 };

--- a/src/aui-form-builder/js/aui-form-builder-field-types.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-types.js
@@ -460,18 +460,5 @@ A.FormBuilderFieldTypes.ATTRS = {
         setter: '_setFieldTypes',
         validator: A.Lang.isArray,
         value: []
-    },
-
-    /**
-     * Collection of strings used to label elements of the UI.
-     *
-     * @attribute strings
-     * @type {Object}
-     */
-    strings: {
-        value: {
-            addField: 'Add Field'
-        },
-        writeOnce: true
     }
 };

--- a/src/aui-form-builder/js/aui-form-builder-field-types.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-types.js
@@ -195,6 +195,58 @@ A.FormBuilderFieldTypes.prototype = {
     },
 
     /**
+     * Check on all created fields if there is one of the same type
+     * of the parameter.
+     *
+     * @method _checkActiveLayoutHasFieldType
+     * @param {Object} fieldType
+     * @return {Boolean}
+     * @protected
+     */
+    _checkActiveLayoutHasFieldType: function(fieldType) {
+        var col,
+            cols,
+            fieldList,
+            row,
+            rows = this.getActiveLayout().get('rows');
+
+        for (row = 0; row < rows.length; row++) {
+            cols = rows[row].get('cols');
+            for (col = 0; col < cols.length; col++) {
+                fieldList = cols[col].get('value');
+                if (fieldList && this._checkListHasFieldType(fieldList, fieldType)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    },
+
+    /**
+     * Checks on all fields of a field list if there is one of the
+     * same type of the parameter.
+     *
+     * @method _checkListHasFieldType
+     * @param {A.FormBuilderFIeldList} fieldList
+     * @param {Object} fieldType
+     * @return {Boolean}
+     * @protected
+     */
+    _checkListHasFieldType: function(fieldList, fieldType) {
+        var fields = fieldList.get('fields'),
+            i;
+
+            for (i = 0; i < fields.length; i++) {
+                if (this._hasFieldType(fieldType, fields[i])) {
+                    return true;
+                }
+            }
+
+        return false;
+    },
+
+    /**
      * Creates the field types panel.
      *
      * @method _createFieldTypesPanel
@@ -244,57 +296,6 @@ A.FormBuilderFieldTypes.prototype = {
                 return true;
             }
         }
-
-        return false;
-    },
-
-    /**
-     * Check all Field created if there is a someone of the same type
-     * of the parameter.
-     *
-     * @method _checkActiveLayoutHasFieldType
-     * @param {Object} fieldType
-     * @return {Boolean}
-     * @protected
-     */
-    _checkActiveLayoutHasFieldType: function(fieldType) {
-        var col,
-            cols,
-            fieldList,
-            row,
-            rows = this.getActiveLayout().get('rows');
-
-        for (row = 0; row < rows.length; row++) {
-            cols = rows[row].get('cols');
-            for (col = 0; col < cols.length; col++) {
-                fieldList = cols[col].get('value');
-                if (fieldList && this._checkListHasFieldType(fieldList, fieldType)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    },
-
-    /**
-     * Fired after the `fields` attribute is set.
-     *
-     * @method _checkListHasFieldType
-     * @param {A.FormBuilderFIeldList} fieldList
-     * @param {Object} fieldType
-     * @return {Boolean}
-     * @protected
-     */
-    _checkListHasFieldType: function(fieldList, fieldType) {
-        var fields = fieldList.get('fields'),
-            i;
-
-            for (i = 0; i < fields.length; i++) {
-                if (this._hasFieldType(fieldType, fields[i])) {
-                    return true;
-                }
-            }
 
         return false;
     },

--- a/src/aui-form-builder/js/aui-form-builder-field-types.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-types.js
@@ -252,29 +252,49 @@ A.FormBuilderFieldTypes.prototype = {
      * Check all Field created if there is a someone of the same type
      * of the parameter.
      *
-     * @method _hasFieldTypeAll
+     * @method _checkActiveLayoutHasFieldType
      * @param {Object} fieldType
      * @return {Boolean}
      * @protected
      */
-    _hasFieldTypeAll: function(fieldType) {
+    _checkActiveLayoutHasFieldType: function(fieldType) {
         var col,
             cols,
-            field,
+            fieldList,
             row,
             rows = this.getActiveLayout().get('rows');
 
         for (row = 0; row < rows.length; row++) {
             cols = rows[row].get('cols');
             for (col = 0; col < cols.length; col++) {
-                field = cols[col].get('value');
-                if (field && (field instanceof A.FormField)) {
-                    if (this._hasFieldType(fieldType, field)) {
-                        return true;
-                    }
+                fieldList = cols[col].get('value');
+                if (fieldList && this._checkListHasFieldType(fieldList, fieldType)) {
+                    return true;
                 }
             }
         }
+
+        return false;
+    },
+
+    /**
+     * Fired after the `fields` attribute is set.
+     *
+     * @method _checkListHasFieldType
+     * @param {A.FormBuilderFIeldList} fieldList
+     * @param {Object} fieldType
+     * @return {Boolean}
+     * @protected
+     */
+    _checkListHasFieldType: function(fieldList, fieldType) {
+        var fields = fieldList.get('fields'),
+            i;
+
+            for (i = 0; i < fields.length; i++) {
+                if (this._hasFieldType(fieldType, fields[i])) {
+                    return true;
+                }
+            }
 
         return false;
     },
@@ -406,7 +426,7 @@ A.FormBuilderFieldTypes.prototype = {
 
         A.Array.each(instance.get('fieldTypes'), function (fieldType) {
             if (fieldType.get('unique')) {
-                fieldType.set('disabled', instance._hasFieldTypeAll(fieldType));
+                fieldType.set('disabled', instance._checkActiveLayoutHasFieldType(fieldType));
             }
         });
     }

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -83,7 +83,6 @@ A.FormBuilderLayoutBuilder.prototype = {
      *
      * @method _addColMoveTarget
      * @param {A.LayoutCol} col
-     * @param {Number} index
      * @protected
      */
     _addColMoveTarget: function(col) {

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -150,8 +150,8 @@ A.FormBuilderLayoutBuilder.prototype = {
     },
 
     /**
-     * Checks if the last row has more the one col, if yes a new row is
-     * created and seted as the last position.
+     * Checks if the last row has more than one col.
+     * If it has, creates and set a new row as the last position.
      *
      * @method _checkLastRow
      * @protected

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -131,7 +131,6 @@ A.FormBuilderLayoutBuilder.prototype = {
             clickColMoveTarget: A.bind(this._clickColMoveTarget, this),
             clickRemoveRow: A.bind(this._clickRemoveRow, this),
             container: this.get('contentBox').one('.' + CSS_LAYOUT),
-            enableRemoveCols: false,
             layout: this.getActiveLayout(),
             removeColMoveButtons: A.bind(this._removeColMoveButtons, this),
             removeColMoveTargets: A.bind(this._removeColMoveTargets, this)

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -319,7 +319,7 @@ A.FormBuilderLayoutBuilder.prototype = {
 
     /**
      * Create a confirmation modal to be used when a remove row button from a row with
-     * fields is clicked. 
+     * fields is clicked.
      *
      * @method _initRemoveConfirmationModal
      * @protected
@@ -335,7 +335,7 @@ A.FormBuilderLayoutBuilder.prototype = {
             visible: false,
             zIndex: 2
         }).render();
-        
+
         modal.addToolbar([
             {
                 cssClass: 'btn-primary',

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -7,13 +7,15 @@
 
 var CSS_CHOOSE_COL_MOVE = A.getClassName('form', 'builder', 'choose', 'col', 'move'),
     CSS_CHOOSE_COL_MOVE_TARGET = A.getClassName('form', 'builder', 'choose', 'col', 'move', 'target'),
-    CSS_COL_MOVING = A.getClassName('form', 'builder', 'col', 'moving'),
     CSS_FIELD = A.getClassName('form', 'builder', 'field'),
     CSS_FIELD_MOVE_BUTTON = A.getClassName('form', 'builder', 'field', 'move', 'button'),
     CSS_FIELD_MOVE_TARGET = A.getClassName('form', 'builder', 'field', 'move', 'target'),
     CSS_FIELD_MOVE_TARGET_INVALID = A.getClassName('form', 'builder', 'field', 'move', 'target', 'invalid'),
     CSS_FIELD_MOVING = A.getClassName('form', 'builder', 'field', 'moving'),
     CSS_LAYOUT = A.getClassName('form', 'builder', 'layout'),
+    CSS_LAYOUT_BUILDER_MOVE_CANCEL = A.getClassName('layout', 'builder', 'move', 'cancel'),
+    CSS_MOVE_COL_TARGET = A.getClassName('layout', 'builder', 'move', 'col', 'target'),
+    CSS_MOVE_TARGET = A.getClassName('layout', 'builder', 'move', 'target'),
     CSS_REMOVE_ROW_MODAL = A.getClassName('form', 'builder', 'remove', 'row', 'modal');
 
 /**
@@ -85,15 +87,8 @@ A.FormBuilderLayoutBuilder.prototype = {
      * @protected
      */
     _addColMoveTarget: function(col) {
-        var cantReceiveMoveTarget,
-            colNode = col.get('node'),
+        var colNode = col.get('node'),
             targetNodes;
-
-        cantReceiveMoveTarget = col.get('value').get('fields').length > 0;
-
-        if (cantReceiveMoveTarget) {
-            return;
-        }
 
         colNode.addClass(CSS_CHOOSE_COL_MOVE_TARGET);
 
@@ -150,8 +145,8 @@ A.FormBuilderLayoutBuilder.prototype = {
     },
 
     /**
-     * Checks if the last row has more than one col.
-     * If it has, creates and set a new row as the last position.
+     * Checks if the last row has more than one col, if yes a new row is
+     * created and set as the last position.
      *
      * @method _checkLastRow
      * @protected
@@ -178,8 +173,7 @@ A.FormBuilderLayoutBuilder.prototype = {
      * @protected
      */
     _chooseColMoveTarget: function(originalFn, cutButton, col) {
-        var colNode = col.get('node'),
-            fieldNode = cutButton.ancestor('.' + CSS_FIELD),
+        var fieldNode = cutButton.ancestor('.' + CSS_FIELD),
             layout = this.getActiveLayout(),
             targetNode;
 
@@ -187,8 +181,6 @@ A.FormBuilderLayoutBuilder.prototype = {
         this._fieldListBeingMoved = col.get('value');
         this._fieldBeingMovedCol = col;
 
-        colNode.addClass(CSS_CHOOSE_COL_MOVE_TARGET);
-        colNode.addClass(CSS_COL_MOVING);
         fieldNode.addClass(CSS_FIELD_MOVING);
 
         targetNode = fieldNode.previous('.' + CSS_FIELD_MOVE_TARGET);
@@ -202,8 +194,14 @@ A.FormBuilderLayoutBuilder.prototype = {
         }
 
         originalFn(cutButton, col);
+        this._addColMoveTarget(col);
 
         layout.normalizeColsHeight(layout.get('node').all('.row'));
+
+        this._cancelMoveFieldHandles = [
+            A.one(A.config.doc).on('click', A.bind(this._onClickOutsideMoveTarget, this)),
+            A.one(A.config.doc).on('key', A.bind(this._onEscKeyPressMoveTarget, this), 'down:27')
+        ];
     },
 
     /**
@@ -217,18 +215,19 @@ A.FormBuilderLayoutBuilder.prototype = {
         var layout = this.getActiveLayout(),
             parentFieldNode = this._fieldBeingMoved.get('content').ancestor('.' + CSS_FIELD),
             row,
-            targetNestedParent = moveTarget.getData('nested-field-parent');
+            targetNestedParent = moveTarget.getData('nested-field-parent'),
+            toolbarMoveIconCancelMode = this._fieldToolbar.getItem('.' + CSS_LAYOUT_BUILDER_MOVE_CANCEL);
+
+        if (toolbarMoveIconCancelMode) {
+            toolbarMoveIconCancelMode.removeClass(CSS_LAYOUT_BUILDER_MOVE_CANCEL);
+        }
 
         if (parentFieldNode) {
             parentFieldNode.getData('field-instance').removeNestedField(this._fieldBeingMoved);
-
-            layout.normalizeColsHeight(new A.NodeList(this.getFieldRow(
-                parentFieldNode.getData('field-instance'))));
         }
         else {
             row = this.getFieldRow(this._fieldBeingMoved);
             this._fieldListBeingMoved.removeField(this._fieldBeingMoved);
-            layout.normalizeColsHeight(new A.NodeList(row));
         }
 
         if (targetNestedParent) {
@@ -239,13 +238,18 @@ A.FormBuilderLayoutBuilder.prototype = {
             );
         }
         else {
-            moveTarget.getData('col').get('value').addField(this._fieldBeingMoved);
+            moveTarget.getData('col').get('value').addField(
+                this._fieldBeingMoved,
+                moveTarget.getData('field-list-index')
+            );
         }
 
         this._layoutBuilder.cancelMove();
         this._removeLayoutCutColButtons();
 
         layout.normalizeColsHeight(new A.NodeList(this.getFieldRow(this._fieldBeingMoved)));
+
+        this._detachCancelMoveFieldEvents();
     },
 
     /**
@@ -288,6 +292,16 @@ A.FormBuilderLayoutBuilder.prototype = {
         lastRow.set('removable', false);
 
         layout.addRow(rows.length, lastRow);
+    },
+
+    /**
+     * Detaches events related to the cancel move field funcionality.
+     *
+     * @method _detachCancelMoveFieldEvents
+     * @protected
+     */
+    _detachCancelMoveFieldEvents: function() {
+        new A.EventHandle(this._cancelMoveFieldHandles).detach();
     },
 
     /**
@@ -359,6 +373,44 @@ A.FormBuilderLayoutBuilder.prototype = {
     },
 
     /**
+     * Fires when click event is triggered.
+     *
+     * @method _onClickOutsideMoveTarget
+     * @param {EventFacade} event
+     * @protected
+     */
+    _onClickOutsideMoveTarget: function(event) {
+        var targetNode = event.target,
+        toolbarMoveIconCancelMode = this._fieldToolbar.getItem('.' + CSS_LAYOUT_BUILDER_MOVE_CANCEL);
+
+        if (toolbarMoveIconCancelMode) {
+            toolbarMoveIconCancelMode.removeClass(CSS_LAYOUT_BUILDER_MOVE_CANCEL);
+        }
+
+        if (!(targetNode.hasClass(CSS_MOVE_TARGET) && targetNode.hasClass(CSS_MOVE_COL_TARGET))) {
+            this._layoutBuilder.cancelMove();
+            this._detachCancelMoveFieldEvents();
+        }
+    },
+
+    /**
+     * Fires when esc key press event is triggered.
+     *
+     * @method _onEscKeyPressMoveTarget
+     * @protected
+     */
+    _onEscKeyPressMoveTarget: function() {
+        var toolbarMoveIconCancelMode = this._fieldToolbar.getItem('.' + CSS_LAYOUT_BUILDER_MOVE_CANCEL);
+
+        if (toolbarMoveIconCancelMode) {
+            toolbarMoveIconCancelMode.removeClass(CSS_LAYOUT_BUILDER_MOVE_CANCEL);
+        }
+
+        this._layoutBuilder.cancelMove();
+        this._detachCancelMoveFieldEvents();
+    },
+
+    /**
      * Fired when mouse enters a toolbar's field.
      *
      * @method _onFormBuilderToolbarFieldMouseEnter
@@ -391,7 +443,6 @@ A.FormBuilderLayoutBuilder.prototype = {
 
         contentBox.all('.' + CSS_CHOOSE_COL_MOVE_TARGET).removeClass(CSS_CHOOSE_COL_MOVE_TARGET);
         contentBox.all('.' + CSS_FIELD_MOVING).removeClass(CSS_FIELD_MOVING);
-        contentBox.all('.' + CSS_COL_MOVING).removeClass(CSS_COL_MOVING);
         contentBox.all('.' + CSS_FIELD_MOVE_TARGET_INVALID).removeClass(CSS_FIELD_MOVE_TARGET_INVALID);
 
         layout.normalizeColsHeight(layout.get('node').all('.row'));

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -28,7 +28,6 @@ var CSS_CHOOSE_COL_MOVE = A.getClassName('form', 'builder', 'choose', 'col', 'mo
 A.FormBuilderLayoutBuilder = function() {};
 
 A.FormBuilderLayoutBuilder.prototype = {
-    TITLE_LAYOUT: 'Edit Layout',
 
     /**
      * Construction logic executed during the `A.FormBuilderLayoutBuilder`
@@ -290,7 +289,7 @@ A.FormBuilderLayoutBuilder.prototype = {
             });
         }
 
-        this._updateHeaderTitle(this.TITLE_LAYOUT);
+        this._updateHeaderTitle(this.get('strings').titleOnEditLayoutMode);
     },
 
     /**
@@ -309,7 +308,7 @@ A.FormBuilderLayoutBuilder.prototype = {
             });
         }
 
-        this._updateHeaderTitle(this.TITLE_REGULAR);
+        this._updateHeaderTitle(this.get('strings').titleOnRegularMode);
     },
 
     /**

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -39,9 +39,9 @@ A.FormBuilderLayoutBuilder.prototype = {
      */
     initializer: function() {
         this.after({
-            create: this._afterFieldCreate,
             modeChange: this._afterLayoutBuilderModeChange,
-            render: this._afterLayoutBuilderRender
+            render: this._afterLayoutBuilderRender,
+            'layout-row:colsChange': this._afterLayoutBuilderColsChange
         });
     },
 
@@ -101,13 +101,18 @@ A.FormBuilderLayoutBuilder.prototype = {
     },
 
     /**
-     * Executed after the `layout:create` is fired.
+     * Executed after the `layout:rowsChange` is fired.
      *
-     * @method _afterFieldCreate
+     * @method _afterLayoutBuilderColsChange
+     * @param {EventFacade} event
      * @protected
      */
-    _afterFieldCreate: function() {
-        this._checkLastEmptyRow();
+    _afterLayoutBuilderColsChange: function(event) {
+        var lastRow = this._getLastRow();
+
+        if (lastRow === event.target) {
+            this._checkLastRow();
+        }
     },
 
     /**
@@ -154,28 +159,19 @@ A.FormBuilderLayoutBuilder.prototype = {
 
         this._removeLayoutCutColButtons();
 
-        this._checkLastEmptyRow();
+        this._checkLastRow();
     },
 
     /**
-     * Checks if the last row is empty.
+     * Checks if the last row has more the one col, if yes a new row is
+     * created and seted as the last position.
      *
-     * @method _checkLastEmptyRow
+     * @method _checkLastRow
      * @protected
      */
-    _checkLastEmptyRow: function() {
-        var cols;
-
-        this._lastRow = this._getLastRow();
-
-        cols = this._lastRow.get('cols');
-
-        for (var i = 0; i < cols.length; i++) {
-            if (A.instanceOf(cols[i].get('value'), A.FormBuilderFieldList) &&
-                (cols[i].get('value').get('fields').length > 0)) {
-                this._createLastRow();
-                break;
-            }
+    _checkLastRow: function() {
+        if (this._getLastRow().get('cols').length > 1) {
+            this._createLastRow();
         }
     },
 
@@ -265,41 +261,17 @@ A.FormBuilderLayoutBuilder.prototype = {
     },
 
     /**
-     * Creates a row with the same layout of the last row.
-     *
-     * @method _copyLastRow
-     * @protected
-     * @return {A.LayoutRow}
-     */
-    _copyLastRow: function() {
-        var cols = this._lastRow.get('cols'),
-            newCols = [];
-
-        for (var i = 0; i < cols.length; i++) {
-            newCols.push(new A.LayoutCol({
-                size: cols[i].get('size')
-            }));
-        }
-
-        return new A.LayoutRow({
-            cols: newCols
-        });
-    },
-
-    /**
      * Creates a new row in the last position.
      *
      * @method _createLastRow
      * @protected
      */
     _createLastRow: function() {
-        var lastRow = this._copyLastRow(),
+        var lastRow = new A.LayoutRow(),
             layout = this.getActiveLayout(),
             rows = layout.get('rows');
 
         layout.addRow(rows.length, lastRow);
-
-        this._lastRow = this._getLastRow();
     },
 
     /**

--- a/src/aui-form-builder/js/aui-form-builder-layout-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder-layout-builder.js
@@ -13,9 +13,7 @@ var CSS_CHOOSE_COL_MOVE = A.getClassName('form', 'builder', 'choose', 'col', 'mo
     CSS_FIELD_MOVE_TARGET = A.getClassName('form', 'builder', 'field', 'move', 'target'),
     CSS_FIELD_MOVE_TARGET_INVALID = A.getClassName('form', 'builder', 'field', 'move', 'target', 'invalid'),
     CSS_FIELD_MOVING = A.getClassName('form', 'builder', 'field', 'moving'),
-    CSS_LAYOUT = A.getClassName('form', 'builder', 'layout'),
-    CSS_LAYOUT_BUILDER_MOVE_CANCEL = A.getClassName('layout', 'builder', 'move', 'cancel'),
-    CSS_LAYOUT_MODE = A.getClassName('form', 'builder', 'layout', 'mode');
+    CSS_LAYOUT = A.getClassName('form', 'builder', 'layout');
 
 /**
  * `A.FormBuilder` extension, which handles the `A.LayoutBuilder` inside it.
@@ -38,7 +36,6 @@ A.FormBuilderLayoutBuilder.prototype = {
      */
     initializer: function() {
         this.after({
-            modeChange: this._afterLayoutBuilderModeChange,
             render: this._afterLayoutBuilderRender,
             'layout-row:colsChange': this._afterLayoutBuilderColsChange
         });
@@ -115,19 +112,6 @@ A.FormBuilderLayoutBuilder.prototype = {
     },
 
     /**
-     * Fired after the `mode` attribute is set.
-     *
-     * @method _afterLayoutBuilderModeChange
-     * @protected
-     */
-    _afterLayoutBuilderModeChange: function() {
-        var layout = this.getActiveLayout();
-
-        this._uiSetLayoutBuilderMode(this.get('mode'));
-        layout.normalizeColsHeight(layout.get('node').all('.row'));
-    },
-
-    /**
      * Fired after this widget is rendered.
      *
      * @method _afterLayoutBuilderRender
@@ -141,6 +125,7 @@ A.FormBuilderLayoutBuilder.prototype = {
             addColMoveTarget: A.bind(this._addColMoveTarget, this),
             clickColMoveTarget: A.bind(this._clickColMoveTarget, this),
             container: this.get('contentBox').one('.' + CSS_LAYOUT),
+            enableRemoveCols: false,
             layout: this.getActiveLayout(),
             removeColMoveButtons: A.bind(this._removeColMoveButtons, this),
             removeColMoveTargets: A.bind(this._removeColMoveTargets, this)
@@ -149,8 +134,6 @@ A.FormBuilderLayoutBuilder.prototype = {
         originalChooseColMoveTargetFn = this._layoutBuilder.get('chooseColMoveTarget');
         this._layoutBuilder.set('chooseColMoveTarget', A.bind(this._chooseColMoveTarget, this,
             originalChooseColMoveTargetFn));
-
-        this._uiSetLayoutBuilderMode(this.get('mode'));
 
         this._eventHandles.push(
             this._fieldToolbar.on('onToolbarFieldMouseEnter', A.bind(this._onFormBuilderToolbarFieldMouseEnter, this))
@@ -223,12 +206,7 @@ A.FormBuilderLayoutBuilder.prototype = {
         var layout = this.getActiveLayout(),
             parentFieldNode = this._fieldBeingMoved.get('content').ancestor('.' + CSS_FIELD),
             row,
-            targetNestedParent = moveTarget.getData('nested-field-parent'),
-            toolbarMoveIconCancelMode = this._fieldToolbar.getItem('.' + CSS_LAYOUT_BUILDER_MOVE_CANCEL);
-
-        if (toolbarMoveIconCancelMode) {
-            toolbarMoveIconCancelMode.removeClass(CSS_LAYOUT_BUILDER_MOVE_CANCEL);
-        }
+            targetNestedParent = moveTarget.getData('nested-field-parent');
 
         if (parentFieldNode) {
             parentFieldNode.getData('field-instance').removeNestedField(this._fieldBeingMoved);
@@ -271,44 +249,6 @@ A.FormBuilderLayoutBuilder.prototype = {
             rows = layout.get('rows');
 
         layout.addRow(rows.length, lastRow);
-    },
-
-    /**
-     * Makes the form builder enter layout mode, where the layout can be edited.
-     *
-     * @method _enterLayoutMode
-     * @protected
-     */
-    _enterLayoutMode: function() {
-        if (this._layoutBuilder) {
-            this._layoutBuilder.setAttrs({
-                enableMoveCols: false,
-                enableMoveRows: true,
-                enableRemoveCols: true,
-                enableRemoveRows: true
-            });
-        }
-
-        this._updateHeaderTitle(this.get('strings').titleOnEditLayoutMode);
-    },
-
-    /**
-     * Makes the form builder exit layout mode.
-     *
-     * @method _exitLayoutMode
-     * @protected
-     */
-    _exitLayoutMode: function() {
-        if (this._layoutBuilder) {
-            this._layoutBuilder.setAttrs({
-                enableMoveCols: true,
-                enableMoveRows: false,
-                enableRemoveCols: false,
-                enableRemoveRows: false
-            });
-        }
-
-        this._updateHeaderTitle(this.get('strings').titleOnRegularMode);
     },
 
     /**
@@ -386,23 +326,5 @@ A.FormBuilderLayoutBuilder.prototype = {
         moveItem.setData('layout-row', colNode.ancestor('.row').getData('layout-row'));
         moveItem.setData('node-col', colNode);
         moveItem.removeClass('hidden');
-    },
-
-    /**
-     * Updates the UI according to the value of the `mode` attribute.
-     *
-     * @method _uiSetLayoutBuilderMode
-     * @param  {String} mode
-     * @protected
-     */
-    _uiSetLayoutBuilderMode: function(mode) {
-        if (mode === A.FormBuilder.MODES.LAYOUT) {
-            this._enterLayoutMode();
-            this.get('boundingBox').addClass(CSS_LAYOUT_MODE);
-        }
-        else {
-            this._exitLayoutMode();
-            this.get('boundingBox').removeClass(CSS_LAYOUT_MODE);
-        }
     }
 };

--- a/src/aui-form-builder/js/aui-form-builder-pages.js
+++ b/src/aui-form-builder/js/aui-form-builder-pages.js
@@ -29,9 +29,9 @@ CSS_PAGE_HEADER_TITLE_HIDE_BORDER = A.getClassName('form', 'builder', 'page', 'h
 A.FormBuilderPages = A.Base.create('form-builder-pages', A.Widget, [], {
 
     TPL_PAGE_HEADER: '<div class="' + CSS_PAGE_HEADER + ' form-inline">' +
-        '<input placeholder="Untitle page" tabindex="1" class="' + CSS_PAGE_HEADER_TITLE + ' ' +
+        '<input placeholder="{untitledPage}" tabindex="1" class="' + CSS_PAGE_HEADER_TITLE + ' ' +
         CSS_PAGE_HEADER_TITLE_HIDE_BORDER + ' form-control" type="text" />' +
-        '<input placeholder="An aditional info about this page" tabindex="2" class="' + CSS_PAGE_HEADER_DESCRIPTION +
+        '<input placeholder="{aditionalInfo}" tabindex="2" class="' + CSS_PAGE_HEADER_DESCRIPTION +
         ' ' +
         CSS_PAGE_HEADER_DESCRIPTION_HIDE_BORDER + ' form-control" type="text" />' +
         '</div>',
@@ -44,24 +44,20 @@ A.FormBuilderPages = A.Base.create('form-builder-pages', A.Widget, [], {
         '</div></div>',
 
     /**
-     * Constructor for the `A.FormBuilderPages`. Lifecycle.
-     *
-     * @method initializer
-     * @protected
-     */
-    initializer: function() {
-        this._defaultTitlePlaceholderValue = 'Untitled Page';
-    },
-
-    /**
      * Renders the `A.FormBuilderPages` UI. Lifecycle.
      *
      * @method renderUI
      * @protected
      */
     renderUI: function() {
+        var headerTemplate;
+
+        headerTemplate = A.Lang.sub(this.TPL_PAGE_HEADER, {
+            aditionalInfo: this.get('strings').aditionalInfo
+        });
+
         this.get('contentBox').append(this.TPL_PAGES);
-        this.get('pageHeader').append(this.TPL_PAGE_HEADER);
+        this.get('pageHeader').append(headerTemplate);
 
         this._getPagination().render();
 
@@ -262,11 +258,15 @@ A.FormBuilderPages = A.Base.create('form-builder-pages', A.Widget, [], {
             title = this.get('titles')[activePageNumber - 1],
             pageHeader = this.get('pageHeader'),
             descriptionNode = pageHeader.one('.' + CSS_PAGE_HEADER_DESCRIPTION),
-            titleNode = pageHeader.one('.' + CSS_PAGE_HEADER_TITLE);
+            titleNode = pageHeader.one('.' + CSS_PAGE_HEADER_TITLE),
+            untitledPageTemplate;
 
         if (!title) {
-            titleNode.attr('placeholder', this._defaultTitlePlaceholderValue + ' (' +
-                activePageNumber + ' of ' + this.get('pagesQuantity') + ')');
+            untitledPageTemplate = A.Lang.sub(this.get('strings').untitledPage, {
+                activePageNumber: activePageNumber,
+                pagesQuantity: this.get('pagesQuantity')
+            });
+            titleNode.attr('placeholder', untitledPageTemplate);
         }
 
         titleNode.set('value', title || '');
@@ -335,6 +335,22 @@ A.FormBuilderPages = A.Base.create('form-builder-pages', A.Widget, [], {
          */
         pagesQuantity: {
             value: 1
+        },
+
+        /**
+         * Collection of strings used to label elements of the UI. To Untitled Page text,
+         * the string used should follow this have placeholder to Active Page Number and
+         * Pages Quantity, e.g. `Untitled Page ({activePageNumber} of {pagesQuantity})`.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                aditionalInfo: 'An aditional info about this page',
+                untitledPage: 'Untitled Page ({activePageNumber} of {pagesQuantity})'
+            },
+            writeOnce: true
         },
 
         /**

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -194,18 +194,14 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
     },
 
     /**
-     * Returns the `fieldListInstance`'s row.
+     * Returns the row of the given field.
      *
      * @method getFieldRow
-     * @param {A.FormBuilderFieldList|A.FormField} val
+     * @param {A.FormField} field
      * @return {Node} The row where is the field parameter
      */
-    getFieldRow: function(val) {
-        if (A.instanceOf(val, A.FormBuilderFieldList)) {
-            return val.get('contentBox').ancestor('.layout-row');
-        }
-
-        return val.get('content').ancestor('.layout-row');
+    getFieldRow: function(field) {
+        return field.get('content').ancestor('.layout-row');
     },
 
     /**
@@ -217,6 +213,7 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
     removeField: function(field) {
         var col,
             parentField,
+            row,
             nestedFieldsNode = field.get('content').ancestor('.form-builder-field-nested');
 
         this._handleRemoveEvent(field);
@@ -228,8 +225,9 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
         }
         else {
             col = field.get('content').ancestor('.col').getData('layout-col');
+            row = this.getFieldRow(field);
             col.get('value').removeField(field);
-            this.getActiveLayout().normalizeColsHeight(new A.NodeList(this.getFieldRow(col.get('value'))));
+            this.getActiveLayout().normalizeColsHeight(new A.NodeList(row));
         }
 
         this._updateUniqueFieldType();

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -331,12 +331,19 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
      * Fired after the `layout:rowsChange` event is triggered.
      *
      * @method _afterLayoutRowsChange
+     * @param {EventFacade} event
      * @protected
      */
-    _afterLayoutRowsChange: function() {
-        this._renderEmptyColumns();
+    _afterLayoutRowsChange: function(event) {
+        var rows = event.newVal;
 
+        for (var i = 0; i < rows.length; i++) {
+            rows[i].set('removable', true);
+        }
+
+        this._renderEmptyColumns();
         this._updateUniqueFieldType();
+        this._checkLastRow();
     },
 
     /**
@@ -355,6 +362,8 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
 
         this._pages.set('activePageNumber', 1);
         this._pages.set('pagesQuantity', this.get('layouts').length);
+
+        this._checkLastRow();
     },
 
     /**

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -527,8 +527,14 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
 
         A.Array.each(rows, function(row) {
             A.Array.each(row.get('cols'), function(col) {
-                if (!col.get('value')) {
+                var colValue = col.get('value');
+
+                if (!colValue) {
                     instance._makeEmptyFieldList(col);
+                }
+
+                if (colValue && colValue._updateRemovableLayoutColProperty) {
+                    colValue._updateRemovableLayoutColProperty();
                 }
             });
         });

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -564,6 +564,8 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
                 layout.set('rows', [new A.LayoutRow()]);
             }
 
+            layout.get('rows')[layout.get('rows').length - 1].set('removable', false);
+            
             layouts.push(layout);
         });
 
@@ -632,7 +634,12 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
         strings: {
             value: {
                 addField: 'Add Field',
-                formTitle: 'Build your form'
+                formTitle: 'Build your form',
+                cancelRemoveRow: 'Cancel',
+                confirmRemoveRow: 'Yes, delete',
+                modalHeader: 'Remove confirmation',
+                removeRowModal: 'You will also delete fields with this row. ' +
+                    'Are you sure you want delete it?'
             },
             writeOnce: true
         }

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -297,7 +297,6 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
         if (this._newFieldContainer) {
             if (A.instanceOf(this._newFieldContainer.get('value'), A.FormBuilderFieldList)) {
                 this._newFieldContainer.get('value').addField(field);
-console.log(this._newFieldContainer.get('removable'));
                 this._newFieldContainer.set('removable', false);
             }
             else {

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -717,6 +717,7 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
          */
         strings: {
             value: {
+                addField: 'Add Field',
                 titleOnRegularMode: 'Build your form',
                 titleOnEditLayoutMode: 'Edit Layout'
             },

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -330,7 +330,6 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
         else {
             this._handleEditEvent(field);
         }
-console.log(1);
         this.getActiveLayout().normalizeColsHeight(new A.NodeList(field.get('content').ancestor('.layout-row')));
 
         this._handleCreateEvent(field);

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -360,6 +360,7 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
      * Fired after the `activePageNumber` change.
      *
      * @method _afterUpdatePageContentChange
+     * @param {EventFacade} event
      * @protected
      */
     _afterUpdatePageContentChange: function(event) {
@@ -373,7 +374,6 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
      * Fire event of create a field.
      *
      * @method _getActiveLayoutIndex
-     * @param {A.FormBuilderFieldBase} field
      * @protected
      */
     _getActiveLayoutIndex: function() {

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -297,6 +297,8 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
         if (this._newFieldContainer) {
             if (A.instanceOf(this._newFieldContainer.get('value'), A.FormBuilderFieldList)) {
                 this._newFieldContainer.get('value').addField(field);
+console.log(this._newFieldContainer.get('removable'));
+                this._newFieldContainer.set('removable', false);
             }
             else {
                 this._addNestedField(

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -279,7 +279,6 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
      */
     _addNestedField: function(field, nested, index) {
         field.addNestedField(index, nested);
-        this.getActiveLayout().normalizeColsHeight(new A.NodeList(this.getFieldRow(nested)));
     },
 
     /**
@@ -331,7 +330,7 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
         else {
             this._handleEditEvent(field);
         }
-
+console.log(1);
         this.getActiveLayout().normalizeColsHeight(new A.NodeList(field.get('content').ancestor('.layout-row')));
 
         this._handleCreateEvent(field);

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -512,9 +512,11 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
     },
 
     /**
-     *
+     * Remove a layout from the form builder. The paramenter `event` has the
+     * layout index to be removed.
      *
      * @method _removeLayout
+     * @params {EventFacade} event
      * @protected
      */
     _removeLayout: function(event) {
@@ -553,6 +555,7 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
      * Sets the `fieldToolbar` attribute.
      *
      * @method _setFieldToolbarConfig
+     * @params {Object} val
      * @return {Object}
      */
     _setFieldToolbarConfig: function(val) {

--- a/src/aui-form-builder/js/aui-form-builder.js
+++ b/src/aui-form-builder/js/aui-form-builder.js
@@ -37,10 +37,8 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
     A.FormBuilderFieldTypes,
     A.FormBuilderLayoutBuilder
 ], {
-    TITLE_REGULAR: 'Build your form',
-
     TPL_EDIT_LAYOUT_BUTTON: '<div class="' + CSS_EDIT_LAYOUT_BUTTON + '">' +
-        '<a>Edit Layout</a></div>',
+        '<a>{editLayout}</a></div>',
     TPL_HEADER: '<div class="' + CSS_HEADER + '">' +
         '<a class="' + CSS_HEADER_BACK +
         '" tabindex="1"><span class="glyphicon glyphicon-chevron-left"></span></a>' +
@@ -93,8 +91,14 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
      * @protected
      */
     renderUI: function() {
+        var layoutButtonNode;
+
+        layoutButtonNode = A.Lang.sub(this.TPL_EDIT_LAYOUT_BUTTON, {
+            editLayout: this.get('strings').titleOnEditLayoutMode
+        });
+
         this._menuEditLayoutItem = new A.MenuItem({
-            content: this.TPL_EDIT_LAYOUT_BUTTON
+            content: layoutButtonNode
         });
 
         this._menu = new A.Menu({
@@ -703,6 +707,20 @@ A.FormBuilder = A.Base.create('form-builder', A.Widget, [
                 return A.Object.hasValue(MODES, val);
             },
             value: MODES.REGULAR
+        },
+
+        /**
+         * Collection of strings used to label elements of the UI.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                titleOnRegularMode: 'Build your form',
+                titleOnEditLayoutMode: 'Edit Layout'
+            },
+            writeOnce: true
         }
     },
 

--- a/src/aui-form-builder/meta/aui-form-builder.json
+++ b/src/aui-form-builder/meta/aui-form-builder.json
@@ -9,7 +9,7 @@
             "aui-form-builder-field-types",
             "aui-form-builder-layout-builder",
             "aui-form-builder-pages",
-            "aui-form-builder-settings-modal"
+            "aui-form-builder-settings-modal",
             "event-focus",
             "event-tap"
         ],

--- a/src/aui-form-builder/meta/aui-form-builder.json
+++ b/src/aui-form-builder/meta/aui-form-builder.json
@@ -38,6 +38,16 @@
         ]
     },
 
+	"aui-form-builder-field-list": {
+		"requires": [
+			"aui-form-builder-field-type",
+			"aui-form-builder-field-types",
+			"aui-form-builder-layout-builder",
+			"aui-menu"
+		],
+        "skinnable": true
+	},
+
     "aui-form-builder-field-sentence": {
         "requires": [
             "aui-form-builder-field-base",

--- a/src/aui-form-builder/meta/aui-form-builder.json
+++ b/src/aui-form-builder/meta/aui-form-builder.json
@@ -95,6 +95,7 @@
         "requires": [
             "aui-classnamemanager",
             "aui-layout-builder",
+            "aui-modal",
             "base",
             "node-base"
         ],

--- a/src/aui-form-builder/meta/aui-form-builder.json
+++ b/src/aui-form-builder/meta/aui-form-builder.json
@@ -9,8 +9,7 @@
             "aui-form-builder-field-types",
             "aui-form-builder-layout-builder",
             "aui-form-builder-pages",
-            "aui-form-builder-settings-modal",
-            "aui-menu",
+            "aui-form-builder-settings-modal"
             "event-focus",
             "event-tap"
         ],
@@ -39,15 +38,14 @@
         ]
     },
 
-	"aui-form-builder-field-list": {
-		"requires": [
-			"aui-form-builder-field-type",
-			"aui-form-builder-field-types",
-			"aui-form-builder-layout-builder",
-			"aui-menu"
-		],
+    "aui-form-builder-field-list": {
+        "requires": [
+            "aui-form-builder-field-type",
+            "aui-form-builder-field-types",
+            "aui-form-builder-layout-builder"
+        ],
         "skinnable": true
-	},
+    },
 
     "aui-form-builder-field-sentence": {
         "requires": [

--- a/src/aui-form-builder/meta/aui-form-builder.json
+++ b/src/aui-form-builder/meta/aui-form-builder.json
@@ -3,6 +3,7 @@
         "requires": [
             "aui-modal",
             "aui-layout",
+            "aui-form-builder-field-list",
             "aui-form-builder-field-toolbar",
             "aui-form-builder-field-type",
             "aui-form-builder-field-types",

--- a/src/aui-form-builder/meta/aui-form-builder.json
+++ b/src/aui-form-builder/meta/aui-form-builder.json
@@ -105,6 +105,7 @@
     "aui-form-builder-pages": {
         "requires": [
             "aui-pagination",
+            "aui-tabview",
             "base",
             "event-valuechange",
             "node-base"

--- a/src/aui-form-builder/tests/unit/aui-form-builder-field-list-tests.html
+++ b/src/aui-form-builder/tests/unit/aui-form-builder-field-list-tests.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+    <title>AUI Form Builder Field List tests</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="stylesheet" href="../../../../build/aui-css/css/bootstrap.css">
+
+    <script src="../../../../build/aui/aui.js"></script>
+    <script src="js/aui-form-builder-field-list-tests.js"></script>
+</head>
+<body class="yui3-skin-sam">
+<div id="logger"></div>
+<div class="row">
+    <div id="container">
+</div>
+</div>
+
+<script>
+YUI({
+    coverage: ['aui-form-builder-field-list'],
+    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
+}).use('test-console', 'test', 'aui-form-builder-field-list-tests', function(Y) {
+    (new Y.Test.Console()).render('#logger');
+    Y.Test.Runner.setName('aui-form-builder-field-list');
+    Y.Test.Runner.run();
+});
+</script>
+</body>
+</html>

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
@@ -78,13 +78,55 @@ YUI.add('aui-form-builder-field-list-tests', function(Y) {
 
             this._fieldList.removeField(sentence);
             Y.Assert.isNull(Y.one('.form-builder-field'));
+        },
+
+        'should set LayoutCol as unremovable when there are fields inside it': function() {
+            var layout,
+                layoutCol,
+                fieldList = new Y.FormBuilderFieldList(),
+                field,
+                form;
+
+            layoutCol = new Y.LayoutCol({
+                value: fieldList
+            });
+
+            field = new Y.FormBuilderFieldText({
+                help: 'Type your full name here',
+                title: 'What\'s your name?'
+            });
+
+            layout = new Y.Layout({
+                rows: [
+                    new Y.LayoutRow({cols: [layoutCol]
+                })]
+            });
+
+            form = new Y.FormBuilder({
+                layouts: [layout],
+            }).render(this._container);
+
+            Y.Assert.isTrue(layoutCol.get('removable'));
+
+            fieldList.addField(field);
+
+            this.wait(function() {
+                Y.Assert.isFalse(layoutCol.get('removable'));
+            }, 0);
         }
     }));
 
     Y.Test.Runner.add(suite);
 
 }, '', {
-    requires: ['aui-form-builder-field-list', 'aui-form-builder-field-sentence', 'node-event-simulate', 'test'],
+    requires: [
+        'aui-form-builder',
+        'aui-form-builder-field-list',
+        'aui-form-builder-field-text',
+        'aui-form-builder-field-sentence',
+        'node-event-simulate',
+        'test'
+    ],
     test: function(Y) {
         return Y.UA.ie === 0 || Y.UA.ie > 8;
     }

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
@@ -1,0 +1,48 @@
+YUI.add('aui-form-builder-field-list-tests', function(Y) {
+
+    var suite = new Y.Test.Suite('aui-form-builder-field-list');
+
+    suite.add(new Y.Test.Case({
+        name: 'AUI Form Builder Field List Unit Tests',
+
+        init: function() {
+            this._container = Y.one('#container');
+        },
+
+        tearDown: function() {
+            this._fieldList && this._fieldList.destroy();
+        },
+
+        createFieldList: function(config) {
+            this._fieldList = new Y.FormBuilderFieldList(config);
+            this._container.append(this._fieldList.get('contentBox'));
+        },
+
+        'should add a field to the field list': function() {
+            this.createFieldList();
+
+            Y.Assert.isNull(Y.one('.form-builder-field'));
+
+            this._fieldList.addField(new Y.FormBuilderFieldSentence());
+            Y.Assert.isNotNull(Y.one('.form-builder-field'));
+        },
+
+        'should remove a field from the field list': function() {
+            var sentence = new Y.FormBuilderFieldSentence();
+
+            this.createFieldList({ fields: [sentence] });
+            Y.Assert.isNotNull(Y.one('.form-builder-field'));
+
+            this._fieldList.removeField(sentence);
+            Y.Assert.isNull(Y.one('.form-builder-field'));
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+
+}, '', {
+    requires: ['aui-form-builder-field-list', 'aui-form-builder-field-sentence', 'node-event-simulate', 'test'],
+    test: function(Y) {
+        return Y.UA.ie === 0 || Y.UA.ie > 8;
+    }
+});

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
@@ -11,11 +11,12 @@ YUI.add('aui-form-builder-field-list-tests', function(Y) {
 
         tearDown: function() {
             this._fieldList && this._fieldList.destroy();
+            this._container.empty();
         },
 
         createFieldList: function(config) {
             this._fieldList = new Y.FormBuilderFieldList(config);
-            this._container.append(this._fieldList.get('contentBox'));
+            this._container.append(this._fieldList.get('content'));
         },
 
         'should add a field to the field list': function() {

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
@@ -28,6 +28,48 @@ YUI.add('aui-form-builder-field-list-tests', function(Y) {
             Y.Assert.isNotNull(Y.one('.form-builder-field'));
         },
 
+        'should add a field between fields in a list': function() {
+            var sentence = new Y.FormBuilderFieldSentence(),
+                sentence2 = new Y.FormBuilderFieldSentence();
+
+            this.createFieldList({ fields: [sentence, sentence2] });
+
+            Y.all('.form-builder-field-list-add-button').item(1).simulate('mouseover');
+            Y.all('.form-builder-field-list-add-button-circle').item(1).simulate('click');
+
+            this._fieldList.addField(new Y.FormBuilderFieldSentence({title: 'between'}));
+
+            Y.Assert.areEqual(Y.all('.form-field-title').item(1).get('innerHTML'), 'between');
+        },
+
+        'should show/hide add button between fields on mouseover/mouseleave': function() {
+            var addButton,
+                sentence = new Y.FormBuilderFieldSentence(),
+                sentence2 = new Y.FormBuilderFieldSentence();
+
+            this.createFieldList({ fields: [sentence, sentence2] });
+
+            addButton = Y.all('.form-builder-field-list-add-button').item(1);
+
+            Y.Assert.isFalse(addButton.hasClass('form-builder-field-list-add-button-visible'));
+
+            addButton.simulate('mouseover');
+            Y.Assert.isTrue(addButton.hasClass('form-builder-field-list-add-button-visible'));
+
+            addButton.simulate('mouseout');
+            Y.Assert.isFalse(addButton.hasClass('form-builder-field-list-add-button-visible'));
+
+            addButton = Y.all('.form-builder-field-list-add-button').item(2);
+
+            Y.Assert.isTrue(addButton.hasClass('form-builder-field-list-add-button-visible'));
+
+            addButton.simulate('mouseover');
+            Y.Assert.isTrue(addButton.hasClass('form-builder-field-list-add-button-visible'));
+
+            addButton.simulate('mouseout');
+            Y.Assert.isTrue(addButton.hasClass('form-builder-field-list-add-button-visible'));
+        },
+
         'should remove a field from the field list': function() {
             var sentence = new Y.FormBuilderFieldSentence();
 

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-field-list-tests.js
@@ -42,6 +42,17 @@ YUI.add('aui-form-builder-field-list-tests', function(Y) {
             Y.Assert.areEqual(Y.all('.form-field-title').item(1).get('innerHTML'), 'between');
         },
 
+        'should add a field to a list in a specific position': function() {
+            var sentence = new Y.FormBuilderFieldSentence(),
+                sentence2 = new Y.FormBuilderFieldSentence();
+
+            this.createFieldList({ fields: [sentence, sentence2] });
+
+            this._fieldList.addField(new Y.FormBuilderFieldSentence({title: 'specific'}), 1);
+
+            Y.Assert.areEqual(Y.all('.form-field-title').item(1).get('innerHTML'), 'specific');
+        },
+
         'should show/hide add button between fields on mouseover/mouseleave': function() {
             var addButton,
                 sentence = new Y.FormBuilderFieldSentence(),

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-field-types-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-field-types-tests.js
@@ -18,9 +18,13 @@ YUI.add('aui-form-builder-field-types-tests', function(Y) {
                         cols: [
                             new Y.LayoutCol({
                                 size: 6,
-                                value: new Y.FormBuilderFieldText({
-                                    help: 'Help',
-                                    title: 'Title'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldText({
+                                            help: 'Help',
+                                            title: 'Title'
+                                        })
+                                    ]
                                 })
                             })
                         ]
@@ -326,34 +330,42 @@ YUI.add('aui-form-builder-field-types-tests', function(Y) {
                         cols: [
                             new Y.LayoutCol({
                                 size: 6,
-                                value: new Y.FormBuilderFieldText({
-                                    help: 'Help',
-                                    nestedFields: [
-                                        new Y.FormBuilderFieldText({
-                                            help: 'Help',
-                                            title: 'Title'
-                                        })
-                                    ],
-                                    title: 'Title'
-                                })
+                                value: new Y.FormBuilderFieldList({
+                                fields: [
+                                    new Y.FormBuilderFieldText({
+                                        help: 'Help',
+                                        nestedFields: [
+                                            new Y.FormBuilderFieldText({
+                                                help: 'Help',
+                                                title: 'Title'
+                                            })
+                                        ],
+                                        title: 'Title'
+                                    })
+                                ]
+                            })
                             }),
                             new Y.LayoutCol({
                                 size: 6,
-                                value: new Y.FormBuilderFieldText({
-                                    help: 'Help',
-                                    nestedFields: [
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
                                         new Y.FormBuilderFieldText({
                                             help: 'Help',
                                             nestedFields: [
-                                                new Y.FormBuilderFieldSentence({
+                                                new Y.FormBuilderFieldText({
                                                     help: 'Help',
+                                                    nestedFields: [
+                                                        new Y.FormBuilderFieldSentence({
+                                                            help: 'Help',
+                                                            title: 'Title'
+                                                        })
+                                                    ],
                                                     title: 'Title'
                                                 })
                                             ],
                                             title: 'Title'
                                         })
-                                    ],
-                                    title: 'Title'
+                                    ]
                                 })
                             })
                         ]
@@ -380,9 +392,13 @@ YUI.add('aui-form-builder-field-types-tests', function(Y) {
                         cols: [
                             new Y.LayoutCol({
                                 size: 6,
-                                value: new Y.FormBuilderFieldSentence({
-                                    help: 'Help',
-                                    title: 'Title'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldSentence({
+                                            help: 'Help',
+                                            title: 'Title'
+                                        })
+                                    ]
                                 })
                             })
                         ]

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -308,13 +308,13 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            // Y.Assert.areEqual(2, visibleTargets.size());
+            Y.Assert.areEqual(3, visibleTargets.size());
 
-            // moveItem.simulate('click');
-            // visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
-            //     return node.getStyle('display') !== 'none';
-            // });
-            // Y.Assert.areEqual(0, visibleTargets.size());
+            moveItem.simulate('click');
+            visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
+                return node.getStyle('display') !== 'none';
+            });
+            Y.Assert.areEqual(0, visibleTargets.size());
         },
 
         'should show valid field move targets for nested field': function() {
@@ -340,7 +340,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            Y.Assert.areEqual(6, visibleTargets.size());
+            Y.Assert.areEqual(5, visibleTargets.size());
 
             moveItem.simulate('click');
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
@@ -463,7 +463,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden' && node.getStyle('display') !== 'none';
             });
-            Y.Assert.areEqual(2, visibleTargets.size());
+            Y.Assert.areEqual(1, visibleTargets.size());
         },
 
         'should always have an empty row in the last position': function() {

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -97,7 +97,8 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             if (Y.UA.mobile) {
                 Y.one('.form-builder-field-content').simulate('click');
-            } else {
+            }
+            else {
                 fieldNode.simulate('mouseover');
                 fieldNode.one('.form-builder-field-toolbar-toggle').simulate('click');
             }

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -84,6 +84,21 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             }
         },
 
+        _moveTargetIsVisible: function () {
+            var row,
+                rowNode,
+                visibleTargets;
+
+            row = this._formBuilder.get('layouts')[0].get('rows')[0];
+            rowNode = row.get('node');
+
+            visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
+                return node.getStyle('display') !== 'none';
+            });
+
+            return !!visibleTargets.size();
+        },
+
         _mockWindowInnerWidth: function (size) {
             Y.Mock.expect(windowNode, {
                 args: ['innerWidth'],
@@ -242,6 +257,83 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             Y.Assert.isNull(Y.one('.form-builder-choose-col-move .form-builder-field-move-target'));
         },
 
+        'should be able to move fields to a different position in a same col': function() {
+            var layout = new Y.Layout({
+                rows: [
+                    new Y.LayoutRow({
+                        cols: [
+                            new Y.LayoutCol({
+                                movableContent: true,
+                                size: 4,
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldSentence({
+                                            title: 'My Title1'
+                                        }),
+                                        new Y.FormBuilderFieldSentence({
+                                            title: 'My Title2'
+                                        })
+                                    ]
+                                })
+                            })
+                        ]
+                    })
+                ]
+            });
+
+            this._createFormBuilder({layouts: [layout]});
+
+            this._toolbar = new Y.FormBuilderFieldToolbar({
+                formBuilder: this._formBuilder
+            });
+
+            Y.Assert.areNotEqual('My Title2', Y.one('.form-field-title').get('innerHTML'));
+
+            this._openToolbar(Y.all('.form-builder-field-content-toolbar').item(1));
+            Y.all('.form-builder-field-toolbar-item').item(2).simulate('click');
+            Y.one('.form-builder-field-move-target').simulate('click');
+
+            Y.Assert.areEqual('My Title2', Y.one('.form-field-title').get('innerHTML'));
+        },
+
+        'should cancel move field action when a click event is triggered in an invalid move target element': function() {
+            this._createFormBuilder();
+
+            this._toolbar = new Y.FormBuilderFieldToolbar({
+                formBuilder: this._formBuilder
+            });
+
+            Y.Assert.isFalse(this._moveTargetIsVisible());
+
+            this._openToolbar();
+            Y.all('.form-builder-field-toolbar-item').item(2).simulate('click');
+            Y.Assert.isTrue(this._moveTargetIsVisible());
+
+            Y.one(Y.config.doc).simulate('click');
+
+            Y.Assert.isFalse(this._moveTargetIsVisible());
+        },
+
+        'should cancel move field action when esc is pressed': function() {
+            this._createFormBuilder();
+
+            this._toolbar = new Y.FormBuilderFieldToolbar({
+                formBuilder: this._formBuilder
+            });
+
+            Y.Assert.isFalse(this._moveTargetIsVisible());
+
+            this._openToolbar();
+            Y.all('.form-builder-field-toolbar-item').item(2).simulate('click');
+            Y.Assert.isTrue(this._moveTargetIsVisible());
+
+            Y.one(Y.config.doc).simulate('keydown', {
+                keyCode: 27
+            });
+
+            Y.Assert.isFalse(this._moveTargetIsVisible());
+        },
+
         'should be able to resize cols': function() {
             var draggable;
 
@@ -334,7 +426,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            Y.Assert.areEqual(6, visibleTargets.size());
+            Y.Assert.areEqual(8, visibleTargets.size());
 
             moveItem.simulate('click');
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
@@ -445,7 +537,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden' && node.getStyle('display') !== 'none';
             });
-            Y.Assert.areEqual(1, visibleTargets.size());
+            Y.Assert.areEqual(4, visibleTargets.size());
         },
 
         'should always have an empty row when a Form Builder is created without rows': function() {

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -76,7 +76,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             });
 
             this._formBuilder = new Y.FormBuilder(Y.merge({
-                layouts: [layout] 
+                layouts: [layout]
             }, config));
 
             if (!skipRender) {

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -38,19 +38,23 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
                             new Y.LayoutCol({
                                 movableContent: true,
                                 size: 4,
-                                value: new Y.FormBuilderFieldSentence({
-                                    help: 'My Help',
-                                    nestedFields: [
-                                        new Y.FormBuilderFieldText({
-                                            help: 'First nested field',
-                                            title: 'Nested Field 1'
-                                        }),
-                                        new Y.FormBuilderFieldText({
-                                            help: 'Second nested field',
-                                            title: 'Nested Field 2'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldSentence({
+                                            help: 'My Help',
+                                            nestedFields: [
+                                                new Y.FormBuilderFieldText({
+                                                    help: 'First nested field',
+                                                    title: 'Nested Field 1'
+                                                }),
+                                                new Y.FormBuilderFieldText({
+                                                    help: 'Second nested field',
+                                                    title: 'Nested Field 2'
+                                                })
+                                            ],
+                                            title: 'My Title'
                                         })
-                                    ],
-                                    title: 'My Title'
+                                    ]
                                 })
                             }),
                             new Y.LayoutCol({
@@ -58,8 +62,12 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
                             }),
                             new Y.LayoutCol({
                                 size: 4,
-                                value: new Y.FormBuilderFieldSentence({
-                                    title: 'Another Field'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldSentence({
+                                            title: 'Another Field'
+                                        })
+                                    ]
                                 })
                             })
                         ]
@@ -300,13 +308,13 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            Y.Assert.areEqual(2, visibleTargets.size());
+            // Y.Assert.areEqual(2, visibleTargets.size());
 
-            moveItem.simulate('click');
-            visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
-                return node.getStyle('display') !== 'none';
-            });
-            Y.Assert.areEqual(0, visibleTargets.size());
+            // moveItem.simulate('click');
+            // visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
+            //     return node.getStyle('display') !== 'none';
+            // });
+            // Y.Assert.areEqual(0, visibleTargets.size());
         },
 
         'should show valid field move targets for nested field': function() {
@@ -332,7 +340,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            Y.Assert.areEqual(4, visibleTargets.size());
+            Y.Assert.areEqual(6, visibleTargets.size());
 
             moveItem.simulate('click');
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
@@ -341,7 +349,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             Y.Assert.areEqual(0, visibleTargets.size());
         },
 
-        'should allow moving the whole field to another column': function() {
+        'should allow moving the whole field list to another column': function() {
             var col,
                 cols,
                 field,
@@ -360,18 +368,16 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             row = this._formBuilder.get('layouts')[0].get('rows')[0];
             cols = row.get('cols');
-            field = cols[0].get('value');
+            field = cols[0].get('value').get('fields')[0];
 
             moveItem.simulate('click');
             cols[1].get('node').one('.layout-builder-move-col-target').simulate('click');
 
             col = row.get('cols')[0];
-            Y.Assert.areNotEqual(field, col.get('value'));
-            Y.Assert.isFalse(col.get('movableContent'));
+            Y.Assert.areNotEqual(field, col.get('value').get('fields')[0]);
 
             col = row.get('cols')[1];
-            Y.Assert.areEqual(field, col.get('value'));
-            Y.Assert.isTrue(col.get('movableContent'));
+            Y.Assert.areEqual(field, col.get('value').get('fields')[0]);
         },
 
         'should allow moving fields inside other fields': function() {
@@ -389,17 +395,17 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             row = this._formBuilder.get('layouts')[0].get('rows')[0];
             cols = row.get('cols');
-            field = cols[0].get('value').get('nestedFields')[0];
+            field = cols[0].get('value').get('fields')[0].get('nestedFields')[0];
 
             this._toolbar._toolbar.one('.glyphicon-move').ancestor().simulate('click');
 
             cols[2].get('node').one('.layout-builder-move-col-target').simulate('click');
 
-            Y.Assert.areEqual(1, cols[0].get('value').get('nestedFields').length);
-            Y.Assert.areNotEqual(field, cols[0].get('value').get('nestedFields')[0]);
+            Y.Assert.areEqual(1, cols[0].get('value').get('fields')[0].get('nestedFields').length);
+            Y.Assert.areNotEqual(field, cols[0].get('value').get('fields')[0].get('nestedFields')[0]);
 
-            Y.Assert.areEqual(1, cols[2].get('value').get('nestedFields').length);
-            Y.Assert.areEqual(field, cols[2].get('value').get('nestedFields')[0]);
+            Y.Assert.areEqual(1, cols[2].get('value').get('fields')[0].get('nestedFields').length);
+            Y.Assert.areEqual(field, cols[2].get('value').get('fields')[0].get('nestedFields')[0]);
         },
 
         'should resizing the row when move a nested field to another col': function() {
@@ -419,7 +425,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             row = this._formBuilder.get('layouts')[0].get('rows')[0];
             cols = row.get('cols');
-            field = cols[0].get('value').get('nestedFields')[0];
+            field = cols[0].get('value').get('fields')[0].get('nestedFields')[0];
 
             heightAfterMode = Y.all('.layout-row-container-row').item(1).getStyle('height');
 
@@ -429,25 +435,11 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             heightBeforeMode = Y.all('.layout-row-container-row').item(1).getStyle('height');
 
-            Y.Assert.areEqual(1, cols[0].get('value').get('nestedFields').length);
-            Y.Assert.areNotEqual(field, cols[0].get('value').get('nestedFields')[0]);
+            Y.Assert.areEqual(1, cols[0].get('value').get('fields')[0].get('nestedFields').length);
+            Y.Assert.areNotEqual(field, cols[0].get('value').get('fields')[0].get('nestedFields')[0]);
 
-            Y.Assert.areEqual(1, cols[2].get('value').get('nestedFields').length);
-            Y.Assert.areEqual(field, cols[2].get('value').get('nestedFields')[0]);
-        },
-
-        'should not have move item if col\'s content is not movable': function() {
-            this._createFormBuilder({
-                mode: Y.FormBuilder.MODES.REGULAR
-            });
-
-            this._formBuilder.get('layouts')[0].get('rows')[0].get('cols')[0].set('movableContent', false);
-
-            this._toolbar = this._formBuilder._fieldToolbar;
-            this._openToolbar();
-
-            Y.Assert.areEqual(5, this._toolbar.get('items').length);
-            Y.Assert.areEqual(4, Y.all('.form-builder-field-toolbar-item:not(.hidden)').size());
+            Y.Assert.areEqual(1, cols[2].get('value').get('fields')[0].get('nestedFields').length);
+            Y.Assert.areEqual(field, cols[2].get('value').get('fields')[0].get('nestedFields')[0]);
         },
 
         'should not have move target if col\'s content is not movable': function() {
@@ -471,42 +463,13 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden' && node.getStyle('display') !== 'none';
             });
-            Y.Assert.areEqual(1, visibleTargets.size());
+            Y.Assert.areEqual(2, visibleTargets.size());
         },
 
         'should always have an empty row in the last position': function() {
             this._formBuilder = new Y.FormBuilder().render('#container');
 
             Y.Assert.areEqual(1, this._formBuilder.get('layouts')[0].get('rows').length);
-        },
-
-        'should add a new empty row with the same layout as the last row when a new field is created in the last row': function() {
-            this._formBuilder = new Y.FormBuilder({ fieldTypes: [
-                {
-                    defaultConfig: {
-                        title: 'Title'
-                    },
-                    fieldClass: Y.FormBuilderFieldSentence,
-                    label: 'Sentence'
-                },
-                {
-                    defaultConfig: {
-                        title: 'Title'
-                    },
-                    fieldClass: Y.FormBuilderFieldText,
-                    label: 'Text'
-                }
-            ] }).render('#container');
-
-            Y.Assert.areEqual(1, this._formBuilder.get('layouts')[0].get('rows').length);
-
-            Y.one('.form-builder-empty-col-add-button').simulate('click');
-            Y.one('.modal-content .field-type').simulate('click');
-            Y.one('.text-data-editor input.form-control').set('value', 'foo');
-            Y.one('.form-builder-field-settings-save').simulate('click');
-            Y.one('.form-builder-field-settings-save').simulate('click');
-
-            Y.Assert.areEqual(2, this._formBuilder.get('layouts')[0].get('rows').length);
         }
     }));
 

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -308,7 +308,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            Y.Assert.areEqual(3, visibleTargets.size());
+            Y.Assert.areEqual(4, visibleTargets.size());
 
             moveItem.simulate('click');
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
@@ -340,7 +340,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
                 return node.getStyle('visibility') !== 'hidden';
             });
-            Y.Assert.areEqual(5, visibleTargets.size());
+            Y.Assert.areEqual(6, visibleTargets.size());
 
             moveItem.simulate('click');
             visibleTargets = rowNode.all('.form-builder-field-move-target').filter(function(node) {
@@ -399,7 +399,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             this._toolbar._toolbar.one('.glyphicon-move').ancestor().simulate('click');
 
-            cols[2].get('node').one('.layout-builder-move-col-target').simulate('click');
+            cols[2].get('node').all('.layout-builder-move-col-target').item(1).simulate('click');
 
             Y.Assert.areEqual(1, cols[0].get('value').get('fields')[0].get('nestedFields').length);
             Y.Assert.areNotEqual(field, cols[0].get('value').get('fields')[0].get('nestedFields')[0]);
@@ -431,7 +431,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             this._toolbar._toolbar.one('.glyphicon-move').ancestor().simulate('click');
 
-            cols[2].get('node').one('.layout-builder-move-col-target').simulate('click');
+            cols[2].get('node').all('.layout-builder-move-col-target').item(1).simulate('click');
 
             heightBeforeMode = Y.all('.layout-row-container-row').item(1).getStyle('height');
 

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -117,7 +117,70 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             Y.Assert.areNotEqual('none', button.getStyle('display'));
         },
 
-        'should be able to remove rows': function() {
+        'should open a confirmation modal when a remove row button from a row with fields is clicked': function() {
+            this._createFormBuilder();
+
+            Y.Assert.isTrue(Y.one('.form-builder-remove-row-modal').hasClass('modal-dialog-hidden'));
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Y.Assert.isFalse(Y.one('.form-builder-remove-row-modal').hasClass('modal-dialog-hidden'));
+        },
+
+        'should remove a row just clicking on remove row button when this row has no field': function() {
+            var layout = new Y.Layout({
+                rows: [
+                    new Y.LayoutRow({
+                        cols: [
+                            new Y.LayoutCol({
+                                movableContent: true,
+                                size: 4,
+                                value: new Y.FormBuilderFieldList()
+                            }),
+                            new Y.LayoutCol({
+                                size: 4
+                            }),
+                            new Y.LayoutCol({
+                                size: 4,
+                                value: new Y.FormBuilderFieldList()
+                            })
+                        ]
+                    })
+                ]
+            });
+            this._createFormBuilder({layouts: [layout]});
+
+            Y.Assert.areEqual(this._formBuilder.get('layouts')[0].get('rows').length, 2);
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Y.Assert.areEqual(this._formBuilder.get('layouts')[0].get('rows').length, 1);
+        },
+
+        'should hide button for removing row when a layout with a single row is added to the form builder': function() {
+            var layout = new Y.Layout({
+                rows: [
+                    new Y.LayoutRow({
+                        cols: [
+                            new Y.LayoutCol({
+                                size: 12,
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldSentence({
+                                            help: 'My Help',
+                                            title: 'My Title'
+                                        })
+                                    ]
+                                })
+                            })
+                        ]
+                    })
+                ]
+            });
+
+            this._createFormBuilder({layouts: [layout]});
+
+            Y.Assert.isNull(Y.one('.layout-builder-remove-row-button'));
+        },
+        'should remove a row with fields only if the confirmation button from the confirmation modal is clicked': function() {
             var button;
 
             this._createFormBuilder();
@@ -126,6 +189,17 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             Y.Assert.isNotNull(button);
             Y.Assert.areNotEqual('none', button.getStyle('display'));
+            Y.Assert.areEqual(this._formBuilder.get('layouts')[0].get('rows').length, 2);
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Y.one('.modal-footer').all('button').item(1).simulate('focus');
+            Y.one('.modal-footer').all('button').item(1).simulate('click');
+            Y.Assert.areEqual(this._formBuilder.get('layouts')[0].get('rows').length, 2);
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Y.one('.modal-footer').all('button').item(0).simulate('focus');
+            Y.one('.modal-footer').all('button').item(0).simulate('click');
+            Y.Assert.areEqual(this._formBuilder.get('layouts')[0].get('rows').length, 1);
         },
 
         'should be able to add cols': function() {

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -107,21 +107,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             windowNode.get = originalWinGet;
         },
 
-        'should the row height adjust on form builder mode change': function() {
-            var height;
-
-            this._createFormBuilder();
-
-            height = Y.all('.layout-row-container-row').item(1).getStyle('height');
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            Y.Assert.isTrue(parseInt(Y.all('.layout-row-container-row').item(1).getStyle('height')) > parseInt(height));
-
-            height = Y.all('.layout-row-container-row').item(1).getStyle('height');
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.REGULAR);
-            Y.Assert.isFalse(parseInt(Y.all('.layout-row-container-row').item(1).getStyle('height')) > parseInt(height));
-        },
-
-        'should be able to add rows on both regular and layout mode': function() {
+        'should be able to add rows': function() {
             var button;
 
             this._createFormBuilder();
@@ -129,54 +115,29 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             button = this._formBuilder.get('contentBox').one('.layout-builder-add-row-area');
             Y.Assert.isNotNull(button);
             Y.Assert.areNotEqual('none', button.getStyle('display'));
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            button = this._formBuilder.get('contentBox').one('.layout-builder-add-row-area');
-            Y.Assert.isNotNull(button);
-            Y.Assert.areNotEqual('none', button.getStyle('display'));
         },
 
-        'should only be able to remove rows on layout mode': function() {
+        'should be able to remove rows': function() {
             var button;
 
             this._createFormBuilder();
 
             button = this._formBuilder.get('contentBox').one('.layout-builder-remove-row-button');
-            Y.Assert.isNull(button);
 
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            button = this._formBuilder.get('contentBox').one('.layout-builder-remove-row-button');
             Y.Assert.isNotNull(button);
             Y.Assert.areNotEqual('none', button.getStyle('display'));
         },
 
-        'should be able to add cols on both regular and layout mode': function() {
+        'should be able to add cols': function() {
             var button;
 
             this._createFormBuilder();
 
             button = this._formBuilder.get('contentBox').one('.layout-builder-add-col');
             Y.Assert.isNotNull(button);
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            button = this._formBuilder.get('contentBox').one('.layout-builder-add-col');
-            Y.Assert.isNotNull(button);
         },
 
-        'should not be able to remove cols on regular mode': function() {
-            var button;
-
-            this._createFormBuilder();
-
-            button = this._formBuilder.get('contentBox').one('.layout-builder-remove-col-button');
-            Y.Assert.isNull(button);
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            button = this._formBuilder.get('contentBox').one('.layout-builder-remove-col-button');
-            Y.Assert.isNotNull(button);
-        },
-
-        'should not be able to move rows on regular mode': function() {
+        'should be able to move rows': function() {
             var button,
                 contentBox;
 
@@ -185,14 +146,10 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             contentBox = this._formBuilder.get('contentBox');
 
             button = contentBox.one('.layout-builder-move-cut-row-button');
-            Y.Assert.isNull(button);
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            button = contentBox.one('.layout-builder-move-cut-row-button');
             Y.Assert.isNotNull(button);
         },
 
-        'should be able to move cols on regular mode': function() {
+        'should be able to move cols': function() {
             this._createFormBuilder();
 
             this._toolbar = new Y.FormBuilderFieldToolbar({
@@ -210,29 +167,13 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             Y.Assert.isNull(Y.one('.form-builder-choose-col-move .form-builder-field-move-target'));
         },
 
-        'should be able to resize cols on both regular and layout mode': function() {
+        'should be able to resize cols': function() {
             var draggable;
 
             this._createFormBuilder();
 
             draggable = this._formBuilder.get('contentBox').one('.layout-builder-resize-col-draggable');
             Y.Assert.isNotNull(draggable);
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            draggable = this._formBuilder.get('contentBox').one('.layout-builder-resize-col-draggable');
-            Y.Assert.isNotNull(draggable);
-        },
-
-        'should add/remove css class when on/off layout mode': function() {
-            this._createFormBuilder();
-
-            Y.Assert.isFalse(this._formBuilder.get('boundingBox').hasClass('form-builder-layout-mode'));
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            Y.Assert.isTrue(this._formBuilder.get('boundingBox').hasClass('form-builder-layout-mode'));
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.REGULAR);
-            Y.Assert.isFalse(this._formBuilder.get('boundingBox').hasClass('form-builder-layout-mode'));
         },
 
         'should update layout when it changes': function() {
@@ -248,21 +189,6 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             Y.Assert.areEqual(1, rowNodes.size());
         },
 
-        'should not break if changing mode and layout before rendering': function() {
-            var button;
-
-            this._createFormBuilder({}, true);
-
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.REGULAR);
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
-
-            this._formBuilder.set('layouts', [new Y.Layout()]);
-
-            button = this._formBuilder.get('contentBox').one('.layout-builder-remove-row-button');
-            Y.Assert.isNull(button);
-        },
-
         'should update with new attributes after rendering': function() {
             var layout,
                 rowNodes;
@@ -276,14 +202,11 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
 
             this._createFormBuilder({}, true);
 
-            this._formBuilder.set('mode', Y.FormBuilder.MODES.LAYOUT);
             this._formBuilder.set('layouts', [layout]);
 
             this._formBuilder.render('#container');
             rowNodes = this._formBuilder.get('contentBox').all('.layout-row');
             Y.Assert.areEqual(2, rowNodes.size());
-
-            Y.Assert.isTrue(this._formBuilder.get('boundingBox').hasClass('form-builder-layout-mode'));
         },
 
         'should show valid field move targets for root field': function() {
@@ -292,9 +215,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
                 rowNode,
                 visibleTargets;
 
-            this._createFormBuilder({
-                mode: Y.FormBuilder.MODES.REGULAR
-            });
+            this._createFormBuilder();
 
             this._toolbar = this._formBuilder._fieldToolbar;
             this._openToolbar();
@@ -323,9 +244,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
                 rowNode,
                 visibleTargets;
 
-            this._createFormBuilder({
-                mode: Y.FormBuilder.MODES.REGULAR
-            });
+            this._createFormBuilder();
 
             this._toolbar = this._formBuilder._fieldToolbar;
 
@@ -356,9 +275,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
                 moveItem,
                 row;
 
-            this._createFormBuilder({
-                mode: Y.FormBuilder.MODES.REGULAR
-            });
+            this._createFormBuilder();
 
             this._toolbar = this._formBuilder._fieldToolbar;
 
@@ -385,9 +302,7 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
                 field,
                 row;
 
-            this._createFormBuilder({
-                mode: Y.FormBuilder.MODES.REGULAR
-            });
+            this._createFormBuilder();
 
             this._toolbar = this._formBuilder._fieldToolbar;
 
@@ -411,13 +326,9 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
         'should resizing the row when move a nested field to another col': function() {
             var cols,
                 field,
-                heightAfterMode,
-                heightBeforeMode,
                 row;
 
-            this._createFormBuilder({
-                mode: Y.FormBuilder.MODES.REGULAR
-            });
+            this._createFormBuilder();
 
             this._toolbar = this._formBuilder._fieldToolbar;
 
@@ -427,13 +338,9 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             cols = row.get('cols');
             field = cols[0].get('value').get('fields')[0].get('nestedFields')[0];
 
-            heightAfterMode = Y.all('.layout-row-container-row').item(1).getStyle('height');
-
             this._toolbar._toolbar.one('.glyphicon-move').ancestor().simulate('click');
 
             cols[2].get('node').all('.layout-builder-move-col-target').item(1).simulate('click');
-
-            heightBeforeMode = Y.all('.layout-row-container-row').item(1).getStyle('height');
 
             Y.Assert.areEqual(1, cols[0].get('value').get('fields')[0].get('nestedFields').length);
             Y.Assert.areNotEqual(field, cols[0].get('value').get('fields')[0].get('nestedFields')[0]);

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-layout-builder-tests.js
@@ -466,10 +466,22 @@ YUI.add('aui-form-builder-layout-builder-tests', function(Y) {
             Y.Assert.areEqual(1, visibleTargets.size());
         },
 
-        'should always have an empty row in the last position': function() {
+        'should always have an empty row when a Form Builder is created without rows': function() {
             this._formBuilder = new Y.FormBuilder().render('#container');
 
             Y.Assert.areEqual(1, this._formBuilder.get('layouts')[0].get('rows').length);
+        },
+
+        'should always add an empty row in the last position when a the previous row had more then one col': function() {
+            var layout;
+
+            this._formBuilder = new Y.FormBuilder().render('#container');
+            layout = this._formBuilder.get('layouts')[0];
+
+            Y.one('.layout-builder-add-col').simulate('click');
+
+            Y.Assert.areEqual(2, layout.get('rows').length);
+            Y.Assert.areEqual(1, layout.get('rows')[1].get('cols').length);
         }
     }));
 

--- a/src/aui-form-builder/tests/unit/js/aui-form-builder-pages-tests.js
+++ b/src/aui-form-builder/tests/unit/js/aui-form-builder-pages-tests.js
@@ -10,7 +10,8 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
         },
 
         setUp: function() {
-            this._container.append('<div id="header"></div><div id="pages"></div>');
+            this._container.append('<div id="header"></div><div id="tabs"></div>' +
+                '<div id="pages"></div>');
         },
 
         tearDown: function() {
@@ -26,7 +27,7 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
          * @return {Y.FormBuilderPages}
          */
         createFormBuilderPages: function(config) {
-            this._pages = new Y.FormBuilderPages(config).render();
+            this._pages = new Y.FormBuilderPages(config);
 
             return this._pages;
         },
@@ -56,8 +57,9 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             pages = this.createFormBuilderPages({
                 activePageNumber: 10,
                 pageHeader: '#header',
-                contentBox: '#pages',
-                pagesQuantity: 10
+                pagesQuantity: 10,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
             });
 
             title = pages.get('pageHeader').one('.form-builder-page-header-title');
@@ -72,10 +74,11 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             this.createFormBuilderPages({
                 activePageNumber: 1,
                 pageHeader: '#header',
-                contentBox: '#pages',
-                pagesQuantity: 1
+                pagesQuantity: 1,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
             });
-
+ 
             Y.Assert.areEqual(3, Y.one('.pagination-content').all('li').size());
 
             Y.one('.form-builder-pages-add-page').simulate('click');
@@ -87,8 +90,9 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             this.createFormBuilderPages({
                 activePageNumber: 2,
                 pageHeader: '#header',
-                contentBox: '#pages',
-                pagesQuantity: 2
+                pagesQuantity: 2,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
             });
 
             Y.Assert.areEqual(4, Y.one('.pagination-content').all('li').size());
@@ -102,6 +106,42 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             Y.Assert.areEqual(3, Y.one('.pagination-content').all('li').size());
         },
 
+        'should add a new tab on addPage button clicked': function() {
+            this.createFormBuilderPages({
+                activePageNumber: 1,
+                pageHeader: '#header',
+                pagesQuantity: 1,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
+            });
+ 
+            Y.Assert.areEqual(1, Y.one('.tabbable-content').all('.tab').size());
+
+            Y.one('.form-builder-pages-add-page').simulate('click');
+
+            Y.Assert.areEqual(2, Y.one('.tabbable-content').all('.tab').size());
+        },
+
+        'should remove the current tab on removePage button clicked': function() {
+            this.createFormBuilderPages({
+                activePageNumber: 2,
+                pageHeader: '#header',
+                pagesQuantity: 2,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
+            });
+
+            Y.Assert.areEqual(2, Y.one('.tabbable-content').all('.tab').size());
+
+            Y.one('.form-builder-pages-remove-page').simulate('click');
+
+            Y.Assert.areEqual(1, Y.one('.tabbable-content').all('.tab').size());
+
+            Y.one('.form-builder-pages-remove-page').simulate('click');
+
+            Y.Assert.areEqual(1, Y.one('.tabbable-content').all('.tab').size());
+        },
+
         'should update `title` attribute on title input change': function() {
             var pages,
                 titleNode;
@@ -109,8 +149,9 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             pages = this.createFormBuilderPages({
                 activePageNumber: 1,
                 pageHeader: '#header',
-                contentBox: '#pages',
-                pagesQuantity: 1
+                pagesQuantity: 1,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
             });
 
             titleNode = Y.one('.form-builder-page-header-title');
@@ -125,14 +166,66 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             });
         },
 
+        'should update tab title on title of the current page change': function() {
+            var pages,
+                titleNode;
+
+            pages = this.createFormBuilderPages({
+                activePageNumber: 1,
+                pageHeader: '#header',
+                pagesQuantity: 1,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
+            });
+
+            Y.one('.form-builder-switch-view').simulate('click');
+
+            titleNode = Y.one('.form-builder-page-header-title');
+
+            Y.Assert.areEqual('Untitled Page (1 of 1)', titleNode.get('placeholder'));
+
+            this._simulateInputChange(titleNode, 'title', function() {
+                Y.Assert.areEqual('1.title', Y.one('.tab-label').text());
+                this._simulateInputChange(titleNode, '', function() {
+                    Y.Assert.areEqual('1.Untitled Page (1 of 1)', Y.one('.tab-label').text());
+                });
+            });
+        },
+
+        'should show/hide the tabview/pagination on switch button clicked': function() {
+            var pages;
+
+            pages = this.createFormBuilderPages({
+                activePageNumber: 1,
+                pageHeader: '#header',
+                pagesQuantity: 1,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
+            });
+
+            Y.Assert.isFalse(Y.one('.pagination-content').hasClass('hide'));
+            Y.Assert.isTrue(Y.one('.tabbable-content').hasClass('hide'));
+
+            Y.one('.form-builder-switch-view').simulate('click');
+
+            Y.Assert.isTrue(Y.one('.pagination-content').hasClass('hide'));
+            Y.Assert.isFalse(Y.one('.tabbable-content').hasClass('hide'));
+
+            Y.one('.form-builder-switch-view').simulate('click');
+
+            Y.Assert.isFalse(Y.one('.pagination-content').hasClass('hide'));
+            Y.Assert.isTrue(Y.one('.tabbable-content').hasClass('hide'));
+        },
+
         'should show the right title on page change': function() {
             var titleNode;
 
             this.createFormBuilderPages({
                 activePageNumber: 1,
                 pageHeader: '#header',
-                contentBox: '#pages',
                 pagesQuantity: 2,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs',
                 titles: ['Title', '']
             });
 
@@ -152,8 +245,9 @@ YUI.add('aui-form-builder-pages-tests', function(Y) {
             pages = this.createFormBuilderPages({
                 activePageNumber: 1,
                 pageHeader: '#header',
-                contentBox: '#pages',
-                pagesQuantity: 1
+                pagesQuantity: 1,
+                paginationContainer: '#pages',
+                tabviewContainer: '#tabs'
             });
 
             descriptionNode = Y.one('.form-builder-page-header-description');

--- a/src/aui-form-builder/tests/unit/js/tests.js
+++ b/src/aui-form-builder/tests/unit/js/tests.js
@@ -301,7 +301,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             this.createFormBuilder();
 
             Y.Assert.areEqual(
-                6,
+                4,
                 Y.one('.form-builder-layout').all('.form-builder-field-list').size()
             );
         },
@@ -322,7 +322,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             }));
 
             Y.Assert.areEqual(
-                7,
+                5,
                 Y.one('.form-builder-layout').all('.form-builder-field-list').size()
             );
         },
@@ -341,7 +341,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             ]);
 
             Y.Assert.areEqual(
-                4,
+                5,
                 Y.one('.form-builder-layout').all('.form-builder-field-list').size()
             );
         },

--- a/src/aui-form-builder/tests/unit/js/tests.js
+++ b/src/aui-form-builder/tests/unit/js/tests.js
@@ -286,6 +286,26 @@ YUI.add('aui-form-builder-tests', function(Y) {
             Y.Assert.areEqual(1, nestedFields.length);
         },
 
+        'should update removable rows before a row is moved': function() {
+            var activeLayout;
+
+            this.createFormBuilder();
+
+            activeLayout = this._formBuilder.getActiveLayout();
+
+            Y.Assert.areEqual(2, activeLayout.get('rows').length);
+            Y.Assert.isTrue(activeLayout.get('rows')[0].get('removable'));
+            Y.Assert.isFalse(activeLayout.get('rows')[1].get('removable'));
+
+            Y.one('.layout-builder-move-cut-button').simulate('click');
+            Y.one('.layout-builder-move-row-target').simulate('click');
+
+            Y.Assert.areEqual(3, activeLayout.get('rows').length);
+            Y.Assert.isTrue(activeLayout.get('rows')[0].get('removable'));
+            Y.Assert.isTrue(activeLayout.get('rows')[1].get('removable'));
+            Y.Assert.isFalse(activeLayout.get('rows')[2].get('removable'));
+        },
+
         'should resize the row when a nested field is edited': function() {
             var field,
                 heightAfterMode,
@@ -380,7 +400,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             this._formBuilder.set('layouts', [layout]);
 
             Y.Assert.areEqual(
-                1,
+                2,
                 Y.all('.form-builder-field-list').size()
             );
 
@@ -397,7 +417,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             }));
 
             Y.Assert.areEqual(
-                2,
+                3,
                 Y.all('.form-builder-field-list').size()
             );
         },

--- a/src/aui-form-builder/tests/unit/js/tests.js
+++ b/src/aui-form-builder/tests/unit/js/tests.js
@@ -33,20 +33,24 @@ YUI.add('aui-form-builder-tests', function(Y) {
                             }),
                             new Y.LayoutCol({
                                 size: 4,
-                                value: new Y.FormBuilderFieldSentence({
-                                    help: 'My Help',
-                                    nestedFields: [
-                                        new Y.FormBuilderFieldText({
-                                            help: 'First nested field',
-                                            title: 'Nested Field 1'
-                                        }),
-                                        new Y.FormBuilderFieldText({
-                                            help: 'Second nested field',
-                                            title: 'Nested Field 2'
-                                        })
-                                    ],
-                                    title: 'My Title'
-                                })
+                                value: new Y.FormBuilderFieldList({
+                                fields: [
+                                    new Y.FormBuilderFieldSentence({
+                                        help: 'My Help',
+                                        nestedFields: [
+                                            new Y.FormBuilderFieldText({
+                                                help: 'First nested field',
+                                                title: 'Nested Field 1'
+                                            }),
+                                            new Y.FormBuilderFieldText({
+                                                help: 'Second nested field',
+                                                title: 'Nested Field 2'
+                                            })
+                                        ],
+                                        title: 'My Title'
+                                    })
+                                ]
+                            })
                             })
                         ]
                     })
@@ -99,7 +103,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
          * @protected
          */
         _clickCreateNewField: function() {
-            Y.one('.form-builder-empty-col-add-button').simulate('click');
+            Y.one('.form-builder-field-list-add-button-circle').simulate('click');
         },
 
         /**
@@ -165,9 +169,13 @@ YUI.add('aui-form-builder-tests', function(Y) {
                             }),
                             new Y.LayoutCol({
                                 size: 4,
-                                value: new Y.FormBuilderFieldText({
-                                    help: 'help',
-                                    title: 'Title'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldText({
+                                            help: 'help',
+                                            title: 'Title'
+                                        })
+                                    ]
                                 })
                             })
                         ]
@@ -189,7 +197,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             });
 
             row = this._formBuilder.getActiveLayout().get('rows')[1].get('cols')[0];
-            Y.Assert.isNotNull(row.get('node').all('.form-builder-empty-col').item(0));
+            Y.Assert.isNotNull(row.get('value').get('fields'));
 
             field = Y.one('.form-builder-field').getData('field-instance');
             this._formBuilder.editField(field);
@@ -198,7 +206,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
 
             this._clickFieldSettingsSaveButton();
 
-            Y.Assert.isNotNull(row.get('node').all('.form-builder-empty-col').item(0));
+            Y.Assert.isNotNull(row.get('value').get('fields'));
         },
 
         'should show field settings when editField method is called': function() {
@@ -216,13 +224,15 @@ YUI.add('aui-form-builder-tests', function(Y) {
         },
 
         'should add a field in nested when addNestedField method is called': function() {
-            var field,
+            var currentCol,
+                field,
                 nestedField,
                 originalNestedFieldLength;
 
             this.createFormBuilder();
+            currentCol = this._formBuilder.getActiveLayout().get('rows')[0].get('cols')[2];
 
-            nestedField = this._formBuilder.getActiveLayout().get('rows')[0].get('cols')[2].get('value').get('nestedFields');
+            nestedField = currentCol.get('value').get('fields')[0].get('nestedFields');
             originalNestedFieldLength = nestedField.length;
 
             field = Y.one('.form-builder-field').getData('field-instance');
@@ -242,25 +252,26 @@ YUI.add('aui-form-builder-tests', function(Y) {
             field = Y.one('.form-builder-field').getData('field-instance');
             col = field.get('content').ancestor('.col').getData('layout-col');
 
-            this._formBuilder.removeField(field);
-            Y.Assert.isNotNull(col.get('node').one('.form-builder-empty-col'));
-            Y.Assert.isNull(col.get('node').one('.form-builder-field'));
+            Y.Assert.areEqual(1, col.get('value').get('fields').length);
 
-            Y.Assert.isFalse(col.get('movableContent'));
+            this._formBuilder.removeField(field);
+            Y.Assert.isNull(col.get('node').one('.form-builder-field'));
+            Y.Assert.areEqual(0, col.get('value').get('fields').length);
         },
 
         'should remove a nested field when clicking on remove button': function() {
             var col,
-                nestedField;
+                nestedField,
+                nestedFields;
 
             this.createFormBuilder();
 
             col = this._formBuilder.getActiveLayout().get('rows')[0].get('cols')[2];
-            nestedField = col.get('value').get('nestedFields')[0];
+            nestedFields = col.get('value').get('fields')[0].get('nestedFields');
+            nestedField = nestedFields[0];
             this._formBuilder.removeField(nestedField);
 
-            Y.Assert.isNull(col.get('node').one('.form-builder-empty-col'));
-            Y.Assert.areEqual(1, col.get('value').get('nestedFields').length);
+            Y.Assert.areEqual(1, nestedFields.length);
         },
 
         'should resize the row when a nested field is edited': function() {
@@ -290,20 +301,9 @@ YUI.add('aui-form-builder-tests', function(Y) {
             this.createFormBuilder();
 
             Y.Assert.areEqual(
-                5,
-                Y.one('.form-builder-layout').all('.form-builder-empty-col').size()
+                6,
+                Y.one('.form-builder-layout').all('.form-builder-field-list').size()
             );
-        },
-
-        'should turn col with null value into empty column': function() {
-            var col;
-
-            this.createFormBuilder();
-
-            col = this._formBuilder.getActiveLayout().get('rows')[1].get('cols')[2];
-            col.set('value', null);
-
-            Y.Assert.isNotNull(col.get('node').one('.form-builder-empty-col'));
         },
 
         'should fill empty columns for new rows': function() {
@@ -322,8 +322,8 @@ YUI.add('aui-form-builder-tests', function(Y) {
             }));
 
             Y.Assert.areEqual(
-                6,
-                Y.one('.form-builder-layout').all('.form-builder-empty-col').size()
+                7,
+                Y.one('.form-builder-layout').all('.form-builder-field-list').size()
             );
         },
 
@@ -341,8 +341,8 @@ YUI.add('aui-form-builder-tests', function(Y) {
             ]);
 
             Y.Assert.areEqual(
-                3,
-                Y.one('.form-builder-layout').all('.form-builder-empty-col').size()
+                4,
+                Y.one('.form-builder-layout').all('.form-builder-field-list').size()
             );
         },
 
@@ -369,7 +369,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
 
             Y.Assert.areEqual(
                 1,
-                Y.all('.form-builder-empty-col').size()
+                Y.all('.form-builder-field-list').size()
             );
 
             this._formBuilder.getActiveLayout().addRow(0, new Y.LayoutRow({
@@ -386,17 +386,8 @@ YUI.add('aui-form-builder-tests', function(Y) {
 
             Y.Assert.areEqual(
                 2,
-                Y.all('.form-builder-empty-col').size()
+                Y.all('.form-builder-field-list').size()
             );
-        },
-
-        'should make empty columns unmovable': function() {
-            var emptyCol;
-
-            this.createFormBuilder();
-            emptyCol = this._formBuilder.getActiveLayout().get('rows')[1].get('cols')[0];
-
-            Y.Assert.isFalse(emptyCol.get('movableContent'));
         },
 
         'should open field types modal': function() {
@@ -407,32 +398,19 @@ YUI.add('aui-form-builder-tests', function(Y) {
         },
 
         'should add a field to a column': function() {
-            var col;
+            var col,
+                fields;
 
             this.createFormBuilder();
             col = this._formBuilder.getActiveLayout().get('rows')[0].get('cols')[0];
-            Y.Assert.isFalse(Y.instanceOf(col.get('value'), Y.FormBuilderFieldSentence));
+            fields = col.get('value').get('fields');
+            Y.Assert.areEqual(0, fields.length);
 
             this._clickCreateNewField();
             this._clickFieldType();
             this._clickFieldSettingsSaveButton();
 
-            Y.Assert.isTrue(Y.instanceOf(col.get('value'), Y.FormBuilderFieldSentence));
-        },
-
-        'should make field columns movable': function() {
-            var col;
-
-            this.createFormBuilder();
-
-            col = this._formBuilder.getActiveLayout().get('rows')[0].get('cols')[0];
-            Y.Assert.isFalse(col.get('movableContent'));
-
-            this._clickCreateNewField();
-            this._clickFieldType();
-            this._clickFieldSettingsSaveButton();
-
-            Y.Assert.isTrue(col.get('movableContent'));
+            Y.Assert.isTrue(Y.instanceOf(fields[0], Y.FormBuilderFieldSentence));
         },
 
         'should change to layout mode when menu button is clicked': function() {
@@ -535,8 +513,12 @@ YUI.add('aui-form-builder-tests', function(Y) {
                         cols: [
                             new Y.LayoutCol({
                                 size: 4,
-                                value: new Y.FormBuilderFieldText({
-                                    title: 'Title'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldText({
+                                            title: 'Title'
+                                        })
+                                    ]
                                 })
                             })
                         ]
@@ -581,8 +563,12 @@ YUI.add('aui-form-builder-tests', function(Y) {
                         cols: [
                             new Y.LayoutCol({
                                 size: 4,
-                                value: new Y.FormBuilderFieldText({
-                                    title: 'Monarch'
+                                value: new Y.FormBuilderFieldList({
+                                    fields: [
+                                        new Y.FormBuilderFieldText({
+                                            title: 'Monarch'
+                                        })
+                                    ]
                                 })
                             })
                         ]
@@ -616,9 +602,13 @@ YUI.add('aui-form-builder-tests', function(Y) {
             this._formBuilder.getActiveLayout().get('rows')[0].set('cols', [
                 new Y.LayoutCol({
                     size: 12,
-                    value: new Y.FormBuilderFieldText({
-                        help: 'not just anybody',
-                        title: 'Monarch'
+                    value: new Y.FormBuilderFieldList({
+                        fields: [
+                            new Y.FormBuilderFieldText({
+                                help: 'not just anybody',
+                                title: 'Monarch'
+                            })
+                        ]
                     })
                 })
             ]);
@@ -632,7 +622,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
 
             this.createFormBuilder();
 
-            addFieldButton = Y.one('.form-builder-empty-col-add-button');
+            addFieldButton = Y.one('.form-builder-field-list-add-button-circle');
             addFieldButton.focus();
             addFieldButton.simulate('keydown', {
                 keyCode: 13
@@ -643,7 +633,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             Y.Assert.isTrue(this._formBuilder._fieldTypesModal.get('visible'));
         },
 
-        'should show toolbar settings when focus on a field': function() {
+        'should show toolbar settings only when focus on a field': function() {
             var node;
 
             this.createFormBuilder();
@@ -653,6 +643,12 @@ YUI.add('aui-form-builder-tests', function(Y) {
             this._formBuilder._onFocus({ target: node });
 
             Y.Assert.isNotNull(Y.one('.form-builder-field-toolbar'));
+
+            node = Y.one('.form-builder-field-list-add-button');
+
+            this._formBuilder._onFocus({ target: node });
+
+            Y.Assert.isNull(Y.one('.form-builder-field-toolbar'));
         },
 
         'should be able to create a layout using an object instead of an instance of Layout': function() {
@@ -773,6 +769,25 @@ YUI.add('aui-form-builder-tests', function(Y) {
             Y.Assert.areEqual(2, this._formBuilder.getActiveLayout().get('rows').length);
             Y.one('.pagination-control').simulate('click');
             Y.Assert.areEqual(1, this._formBuilder.getActiveLayout().get('rows').length);
+        },
+
+        'should only update the DOM content when the list of layouts to be seted but before form builder to be rendered': function() {
+            var markup,
+                formbuilder = new Y.FormBuilder({
+                    layouts: [new Y.Layout(), new Y.Layout()],
+                });
+
+            Y.one('#container').empty();
+
+            markup = Y.one('#container').get('innerHTML');
+
+            formbuilder.set('layouts', [new Y.Layout()]);
+            Y.Assert.areEqual(markup, Y.one('#container').get('innerHTML'));
+
+            formbuilder.render('#container');
+
+            formbuilder.set('layouts', [new Y.Layout(), new Y.Layout()]);
+            Y.Assert.areNotEqual(markup, Y.one('#container').get('innerHTML'));
         }
     }));
 

--- a/src/aui-form-builder/tests/unit/js/tests.js
+++ b/src/aui-form-builder/tests/unit/js/tests.js
@@ -413,36 +413,6 @@ YUI.add('aui-form-builder-tests', function(Y) {
             Y.Assert.isTrue(Y.instanceOf(fields[0], Y.FormBuilderFieldSentence));
         },
 
-        'should change to layout mode when menu button is clicked': function() {
-            var contentBox;
-
-            this.createFormBuilder();
-
-            contentBox = this._formBuilder.get('contentBox');
-            contentBox.one('.form-builder-menu-button').simulate('click');
-            contentBox.one('.form-builder-edit-layout-button').simulate('click');
-
-            Y.Assert.areEqual(Y.FormBuilder.MODES.LAYOUT, this._formBuilder.get('mode'));
-
-            contentBox.one('.form-builder-header-back').simulate('click');
-            Y.Assert.areEqual(Y.FormBuilder.MODES.REGULAR, this._formBuilder.get('mode'));
-        },
-
-        'should change to layout mode when menu button is key pressed': function() {
-            var contentBox;
-
-            this.createFormBuilder();
-
-            contentBox = this._formBuilder.get('contentBox');
-            contentBox.one('.form-builder-menu-button').simulate('keypress', { keyCode: 13 });
-            contentBox.one('.form-builder-edit-layout-button').simulate('keypress', { keyCode: 13 });
-
-            Y.Assert.areEqual(Y.FormBuilder.MODES.LAYOUT, this._formBuilder.get('mode'));
-
-            contentBox.one('.form-builder-header-back').simulate('keypress', { keyCode: 13 });
-            Y.Assert.areEqual(Y.FormBuilder.MODES.REGULAR, this._formBuilder.get('mode'));
-        },
-
         'should show corret label when open settings editor': function() {
             var field;
 

--- a/src/aui-form-builder/tests/unit/js/tests.js
+++ b/src/aui-form-builder/tests/unit/js/tests.js
@@ -771,7 +771,7 @@ YUI.add('aui-form-builder-tests', function(Y) {
             Y.Assert.areEqual(1, this._formBuilder.getActiveLayout().get('rows').length);
         },
 
-        'should only update the DOM content when the list of layouts to be seted but before form builder to be rendered': function() {
+        'should only update the DOM content when setting list of layouts after form builder is rendered': function() {
             var markup,
                 formbuilder = new Y.FormBuilder({
                     layouts: [new Y.Layout(), new Y.Layout()],

--- a/src/aui-form-builder/tests/unit/js/tests.js
+++ b/src/aui-form-builder/tests/unit/js/tests.js
@@ -223,6 +223,18 @@ YUI.add('aui-form-builder-tests', function(Y) {
             Y.Assert.isFalse(Y.one('.form-builder-field-settings').hasClass('modal-dialog-hidden'));
         },
 
+        'should create unremovable layout column for column with form': function() {
+            var cols;
+
+            this.createFormBuilder();
+
+            cols = this._formBuilder.getActiveLayout().get('rows')[0].get('cols');
+
+            Y.Assert.isTrue(cols[0].get('removable'));
+            Y.Assert.isTrue(cols[1].get('removable'));
+            Y.Assert.isFalse(cols[2].get('removable'));
+        },
+
         'should add a field in nested when addNestedField method is called': function() {
             var currentCol,
                 field,

--- a/src/aui-layout/HISTORY.md
+++ b/src/aui-layout/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column
 * [AUI-1887](https://issues.liferay.com/browse/AUI-1887) Form builder should have pages, not page breaks
 * [AUI-1858](https://issues.liferay.com/browse/AUI-1858) FormBuilder should be able to receive layout as a configuration object
 * [AUI-1830](https://issues.liferay.com/browse/AUI-1830) Button to move field should be inside the field's toolbar

--- a/src/aui-layout/HISTORY.md
+++ b/src/aui-layout/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1930](https://issues.liferay.com/browse/AUI-1930) Change functionality of add cols
 * [AUI-1939](https://issues.liferay.com/browse/AUI-1939) Fix form builder column resizing after the first page / layout
 * [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col
 * [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows

--- a/src/aui-layout/HISTORY.md
+++ b/src/aui-layout/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1939](https://issues.liferay.com/browse/AUI-1939) Fix form builder column resizing after the first page / layout
 * [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col
 * [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows
 * [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder

--- a/src/aui-layout/HISTORY.md
+++ b/src/aui-layout/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column
 * [AUI-1887](https://issues.liferay.com/browse/AUI-1887) Form builder should have pages, not page breaks
 * [AUI-1858](https://issues.liferay.com/browse/AUI-1858) FormBuilder should be able to receive layout as a configuration object

--- a/src/aui-layout/HISTORY.md
+++ b/src/aui-layout/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1928](https://issues.liferay.com/browse/AUI-1928) Fields should be moved between others field in a same col
 * [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows
 * [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column

--- a/src/aui-layout/HISTORY.md
+++ b/src/aui-layout/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1918](https://issues.liferay.com/browse/AUI-1918) Change functionality of remove rows
 * [AUI-1922](https://issues.liferay.com/browse/AUI-1922) Fixing localization issues on Form Builder
 * [AUI-1885](https://issues.liferay.com/browse/AUI-1885) Allows adding multiple fields on the same column
 * [AUI-1887](https://issues.liferay.com/browse/AUI-1887) Form builder should have pages, not page breaks

--- a/src/aui-layout/assets/aui-layout-builder-remove-row-core.css
+++ b/src/aui-layout/assets/aui-layout-builder-remove-row-core.css
@@ -1,0 +1,7 @@
+.layout-builder-remove-row-button {
+    border-radius: 50%;
+    position: absolute;
+    right: -10px;
+    top: -10px;
+    z-index: 1;
+}

--- a/src/aui-layout/assets/aui-layout-builder-resize-col-core.css
+++ b/src/aui-layout/assets/aui-layout-builder-resize-col-core.css
@@ -50,5 +50,5 @@
 }
 
 .layout-builder-resize-col-breakpoint-over .layout-builder-resize-col-breakpoint-line, .layout-builder-resize-col-breakpoint-line:focus {
-    border-color: red;
+    border-color: #00a3ff;
 }

--- a/src/aui-layout/assets/aui-layout-row-core.css
+++ b/src/aui-layout/assets/aui-layout-row-core.css
@@ -1,3 +1,4 @@
 .layout-row-container-row {
     margin-bottom: 15px;
+    position: relative;
 }

--- a/src/aui-layout/js/aui-layout-builder-add-col.js
+++ b/src/aui-layout/js/aui-layout-builder-add-col.js
@@ -11,7 +11,7 @@ var CSS_ADD_COL = A.getClassName('layout', 'builder', 'add', 'col'),
     SELECTOR_ROW = '.layout-row',
     TPL_ADD_COL = '<div class="' + CSS_ADD_COL + '" tabindex="5">' +
         '<span class="glyphicon glyphicon-th-large"></span>' +
-        '<span class="' + CSS_ADD_COL_TEXT + '">Add Column</span>' +
+        '<span class="' + CSS_ADD_COL_TEXT + '">{addColumn}</span>' +
         '</div>';
 
 /**
@@ -140,14 +140,18 @@ A.LayoutBuilderAddCol.prototype = {
     _appendAddColButtonToSingleRow: function(row) {
         var addColLeft,
             addColRight,
+            addColTemplate,
             colsLength,
             layoutRow = row.getData('layout-row');
 
         colsLength = layoutRow.get('cols').length;
+        addColTemplate = A.Lang.sub(TPL_ADD_COL, {
+            addColumn: this.get('strings').addColumn
+        });
 
         if (colsLength < layoutRow.get('maximumCols')) {
-            addColLeft = A.Node.create(TPL_ADD_COL).addClass(CSS_ADD_COL_LEFT);
-            addColRight = A.Node.create(TPL_ADD_COL).addClass(CSS_ADD_COL_RIGHT);
+            addColLeft = A.Node.create(addColTemplate).addClass(CSS_ADD_COL_LEFT);
+            addColRight = A.Node.create(addColTemplate).addClass(CSS_ADD_COL_RIGHT);
 
             row.append(addColLeft);
             row.append(addColRight);

--- a/src/aui-layout/js/aui-layout-builder-add-col.js
+++ b/src/aui-layout/js/aui-layout-builder-add-col.js
@@ -27,7 +27,8 @@ var ADD_COLUMN_ACTION = 'addColumn',
 A.LayoutBuilderAddCol = function() {};
 
 A.LayoutBuilderAddCol.prototype = {
-    TPL_RESIZE_ADD_COL: '<div class="' + CSS_RESIZE_COL_DRAGGABLE + ' ' + CSS_ADD_COL_DRAGGABLE + '">' +
+    TPL_RESIZE_ADD_COL: '<div data-layout-action="' + ADD_COLUMN_ACTION + '" class="' + 
+        CSS_RESIZE_COL_DRAGGABLE + ' ' + CSS_ADD_COL_DRAGGABLE + '">' +
         '<div class="' + CSS_RESIZE_COL_DRAGGABLE_BORDER + '"></div>' +
         '<div class="' + CSS_RESIZE_COL_DRAGGABLE_HANDLE + '" tabindex="8">' +
         '<span class="' + CSS_ADD_COL_DRAGGABLE_HANDLE + '"></span></div></div>',
@@ -125,41 +126,28 @@ A.LayoutBuilderAddCol.prototype = {
      * @protected
      */
     _appendAddColButtonToSingleRow: function(row) {
-        var addColLeftButton,
-            addColLeftTemplate,
-            addColRightButton,
-            addColRightTemplate,
-            colsLength,
-            cols,
+        var cols,
             layoutRow = row.getData('layout-row'),
             draggableLeft,
             draggableRight;
 
         cols = layoutRow.get('cols');
-        colsLength = cols.length;
-        addColLeftTemplate = A.Lang.sub(this.TPL_RESIZE_ADD_COL);
-        addColLeftButton = this.get('addButtonLeftClass');
-        addColRightTemplate = A.Lang.sub(this.TPL_RESIZE_ADD_COL);
-        addColRightButton = this.get('addButtonRightClass');
 
-        if (colsLength < layoutRow.get('maximumCols')) {
-            draggableLeft = A.Node.create(addColLeftTemplate);
-            draggableRight = A.Node.create(addColRightTemplate);
+        if (cols.length < layoutRow.get('maximumCols')) {
+            draggableLeft = A.Node.create(this.TPL_RESIZE_ADD_COL);
+            draggableRight = A.Node.create(this.TPL_RESIZE_ADD_COL);
 
             draggableLeft.one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).addClass(CSS_RESIZE_COL_DRAGGABLE_HANDLE_EXPAND_LEFT);
-            draggableLeft.one('.' + CSS_ADD_COL_DRAGGABLE_HANDLE).addClass(addColLeftButton);
+            draggableLeft.one('.' + CSS_ADD_COL_DRAGGABLE_HANDLE).addClass(this.get('addButtonLeftClass'));
             draggableLeft.setStyle('left', '0%');
-            draggableLeft.setData('layout-action', ADD_COLUMN_ACTION);
             draggableLeft.setData('layout-position', 0);
-            draggableLeft.setData('layout-col1', undefined);
             draggableLeft.setData('layout-col2', cols[0]);
+            
             draggableRight.one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).addClass(CSS_RESIZE_COL_DRAGGABLE_HANDLE_EXPAND_RIGHT);
-            draggableRight.one('.' + CSS_ADD_COL_DRAGGABLE_HANDLE).addClass(addColRightButton);
+            draggableRight.one('.' + CSS_ADD_COL_DRAGGABLE_HANDLE).addClass(this.get('addButtonRightClass'));
             draggableRight.setStyle('left', '100%');
-            draggableRight.setData('layout-action', ADD_COLUMN_ACTION);
             draggableRight.setData('layout-position', layoutRow.get('maximumCols'));
             draggableRight.setData('layout-col1', cols[cols.length - 1]);
-            draggableRight.setData('layout-col2', undefined);
 
             row.append(draggableLeft);
             row.append(draggableRight);
@@ -181,6 +169,16 @@ A.LayoutBuilderAddCol.prototype = {
     },
 
     /**
+     * Removes all add col buttons.
+     *
+     * @method _removeAddColButton
+     * @protected
+     */
+    _removeAddColButton: function() {
+        this._layoutContainer.all('.' + CSS_ADD_COL_DRAGGABLE).remove();
+    },
+
+    /**
      * Updates the UI according to the value of the `enableAddCols` attribute.
      *
      * @method _uiSetEnableAddCols
@@ -196,16 +194,6 @@ A.LayoutBuilderAddCol.prototype = {
             this._removeAddColButton();
             this._unbindAddColEvents();
         }
-    },
-
-    /**
-     * Removes all add col buttons.
-     *
-     * @method _removeAddColButton
-     * @protected
-     */
-    _removeAddColButton: function() {
-        this._layoutContainer.all('.' + CSS_ADD_COL_DRAGGABLE).remove();
     },
 
     /**
@@ -232,20 +220,19 @@ A.LayoutBuilderAddCol.prototype = {
  */
 A.LayoutBuilderAddCol.ATTRS = {
     /**
-     * Flag indicating if the feature of adding columns to the layout is
-     * enabled or not.
+     * Class name to the add handler on the left side of the layout
      *
-     * @attribute enableAddCols
-     * @default true
-     * @type {Boolean}
+     * @attribute addButtonLeftClass
+     * @default "glyphicon glyphicon-hand-right"
+     * @type {String}
      */
-    enableAddCols: {
-        validator: A.Lang.isBoolean,
-        value: true
+    addButtonLeftClass: {
+        validator: A.Lang.isString,
+        value: 'glyphicon glyphicon-hand-right'
     },
 
     /**
-     * Class name to the add handler on the right
+     * Class name to the add handler on the right side of the layout
      *
      * @attribute addButtonRightClass
      * @default "glyphicon glyphicon-hand-left"
@@ -257,14 +244,15 @@ A.LayoutBuilderAddCol.ATTRS = {
     },
 
     /**
-     * Class name to the add handler on the left
+     * Flag indicating if the feature of adding columns to the layout is
+     * enabled or not.
      *
-     * @attribute addButtonLeftClass
-     * @default "glyphicon glyphicon-hand-right"
-     * @type {String}
+     * @attribute enableAddCols
+     * @default true
+     * @type {Boolean}
      */
-    addButtonLeftClass: {
-        validator: A.Lang.isString,
-        value: 'glyphicon glyphicon-hand-right'
+    enableAddCols: {
+        validator: A.Lang.isBoolean,
+        value: true
     }
 };

--- a/src/aui-layout/js/aui-layout-builder-move.js
+++ b/src/aui-layout/js/aui-layout-builder-move.js
@@ -72,26 +72,6 @@ LayoutBuilderMove.prototype = {
     },
 
     /**
-     * Fired after the `enableMoveCols` attribute changes.
-     *
-     * @method _afterEnableMoveColsChange
-     * @protected
-     */
-    _afterEnableMoveColsChange: function() {
-        this._resetMoveUI();
-    },
-
-    /**
-     * Fired after the `enableMoveRows` attribute changes.
-     *
-     * @method _afterEnableMoveRowsChange
-     * @protected
-     */
-    _afterEnableMoveRowsChange: function() {
-        this._resetMoveUI();
-    },
-
-    /**
      * Destructor implementation for the `A.LayoutBuilderMove` class. Lifecycle.
      *
      * @method destructor
@@ -138,9 +118,30 @@ LayoutBuilderMove.prototype = {
      */
     _addColMoveTarget: function(col, index) {
         var target = A.Node.create(TPL_MOVE_TARGET);
+
         target.setData('col-index', index);
         target.addClass(CSS_MOVE_COL_TARGET);
         col.get('node').append(target);
+    },
+
+    /**
+     * Fired after the `enableMoveCols` attribute changes.
+     *
+     * @method _afterEnableMoveColsChange
+     * @protected
+     */
+    _afterEnableMoveColsChange: function() {
+        this._resetMoveUI();
+    },
+
+    /**
+     * Fired after the `enableMoveRows` attribute changes.
+     *
+     * @method _afterEnableMoveRowsChange
+     * @protected
+     */
+    _afterEnableMoveRowsChange: function() {
+        this._resetMoveUI();
     },
 
     /**

--- a/src/aui-layout/js/aui-layout-builder-move.js
+++ b/src/aui-layout/js/aui-layout-builder-move.js
@@ -523,6 +523,7 @@ LayoutBuilderMove.prototype = {
      * @protected
      */
     _onMouseClickOnMoveCutButton: function(event) {
+        event.stopPropagation();
         this._clickOnCutButton(event.currentTarget);
     },
 

--- a/src/aui-layout/js/aui-layout-builder-remove-col.js
+++ b/src/aui-layout/js/aui-layout-builder-remove-col.js
@@ -86,7 +86,9 @@ A.LayoutBuilderRemoveCol.prototype = {
         var col = event.target.get('node');
 
         if (!event.newVal) {
-            col.one('.' + CSS_REMOVE_COL).remove();
+            if (col.one('.' + CSS_REMOVE_COL)) {
+                col.one('.' + CSS_REMOVE_COL).remove();
+            }
         }
         else {
             col.append(A.Node.create(TPL_REMOVE_COL));

--- a/src/aui-layout/js/aui-layout-builder-remove-row.js
+++ b/src/aui-layout/js/aui-layout-builder-remove-row.js
@@ -7,7 +7,7 @@
 var CSS_REMOVE_ROW = A.getClassName('layout', 'builder', 'remove', 'row', 'button'),
     SELECTOR_ROW = '.layout-row',
     TPL_REMOVE_ROW_BUTTON = '<button class="btn btn-default btn-xs ' + CSS_REMOVE_ROW + '" tabindex="4" type="button">' +
-        '<span class="glyphicon glyphicon-trash"></span> Remove Row</button>';
+        '<span class="glyphicon glyphicon-trash"></span>{removeRow}</button>';
 
 /**
  * A base class for Layout Remove Row.
@@ -153,7 +153,11 @@ LayoutBuilderRemoveRow.prototype = {
      * @protected
      */
     _insertRemoveButtonBeforeRow: function(layoutRow, row) {
-        var removeRowButton = A.Node.create(TPL_REMOVE_ROW_BUTTON);
+        var removeRowButton;
+
+        removeRowButton = A.Node.create(A.Lang.sub(TPL_REMOVE_ROW_BUTTON, {
+            removeRow: this.get('strings').removeRow
+        }));
 
         removeRowButton.setData('layout-row', layoutRow);
         this._layoutContainer.insertBefore(removeRowButton, row);

--- a/src/aui-layout/js/aui-layout-builder-remove-row.js
+++ b/src/aui-layout/js/aui-layout-builder-remove-row.js
@@ -8,7 +8,6 @@ var CSS_REMOVE_ROW = A.getClassName('layout', 'builder', 'remove', 'row', 'butto
     SELECTOR_ROW = '.layout-row',
     TPL_REMOVE_ROW_BUTTON = '<button class="btn btn-default btn-xs ' + CSS_REMOVE_ROW + '" tabindex="4" type="button">' +
         '<span class="glyphicon glyphicon-trash"></span></button>';
-
 /**
  * A base class for Layout Remove Row.
  *
@@ -69,6 +68,29 @@ LayoutBuilderRemoveRow.prototype = {
     },
 
     /**
+     * Fired after the `removable` attribute changes.
+     *
+     * @method _afterRemoveRowRemovableChange
+     * @protected
+     */
+    _afterRemoveRowRemovableChange: function(event) {
+        var containerRow = event.target.get('node'),
+            layoutRow = event.target,
+            removeRowButton;
+
+        removeRowButton = containerRow.one('.' + CSS_REMOVE_ROW);
+
+        if (!event.newVal) {
+            if (removeRowButton) {
+                removeRowButton.remove();
+            }
+        }
+        else {
+            this._insertRemoveButtonBeforeRow(layoutRow, containerRow.one(SELECTOR_ROW));
+        }
+    },
+
+    /**
      * Fired after `rows` attribute changes.
      *
      * @method _afterRemoveRowRowsChange
@@ -106,27 +128,6 @@ LayoutBuilderRemoveRow.prototype = {
                 instance._insertRemoveButtonBeforeRow(layoutRow, row);
             }
         });
-    },
-
-    /**
-     * Fired after the `removable` attribute changes.
-     *
-     * @method _afterRemoveRowRemovableChange
-     * @protected
-     */
-    _afterRemoveRowRemovableChange: function(event) {
-        var containerRow = event.target.get('node'),
-            layoutRow = event.target,
-            removeRowButton;
-
-        removeRowButton = containerRow.one('.' + CSS_REMOVE_ROW);
-
-        if (!event.newVal) {
-            removeRowButton.remove();
-        }
-        else {
-            this._insertRemoveButtonBeforeRow(layoutRow, containerRow.one(SELECTOR_ROW));
-        }
     },
 
     /**

--- a/src/aui-layout/js/aui-layout-builder-remove-row.js
+++ b/src/aui-layout/js/aui-layout-builder-remove-row.js
@@ -7,7 +7,7 @@
 var CSS_REMOVE_ROW = A.getClassName('layout', 'builder', 'remove', 'row', 'button'),
     SELECTOR_ROW = '.layout-row',
     TPL_REMOVE_ROW_BUTTON = '<button class="btn btn-default btn-xs ' + CSS_REMOVE_ROW + '" tabindex="4" type="button">' +
-        '<span class="glyphicon glyphicon-trash"></span>{removeRow}</button>';
+        '<span class="glyphicon glyphicon-trash"></span></button>';
 
 /**
  * A base class for Layout Remove Row.
@@ -155,9 +155,7 @@ LayoutBuilderRemoveRow.prototype = {
     _insertRemoveButtonBeforeRow: function(layoutRow, row) {
         var removeRowButton;
 
-        removeRowButton = A.Node.create(A.Lang.sub(TPL_REMOVE_ROW_BUTTON, {
-            removeRow: this.get('strings').removeRow
-        }));
+        removeRowButton = A.Node.create(TPL_REMOVE_ROW_BUTTON);
 
         removeRowButton.setData('layout-row', layoutRow);
         this._layoutContainer.insertBefore(removeRowButton, row);
@@ -171,10 +169,12 @@ LayoutBuilderRemoveRow.prototype = {
      * @protected
      */
     _onMouseClickRemoveRowEvent: function(event) {
-        var removeRowButton = event.target,
+        var removeRowButton = event.currentTarget,
             row = removeRowButton.getData('layout-row');
 
-        this.get('layout').removeRow(row);
+        if (this.get('clickRemoveRow')(row)){
+            this.get('layout').removeRow(row);
+        }
     },
 
     /**
@@ -228,6 +228,19 @@ LayoutBuilderRemoveRow.prototype = {
  * @static
  */
 LayoutBuilderRemoveRow.ATTRS = {
+    /**
+     * Check if the row can be remove when remove button is clicked.  
+     *
+     * @attribute clickRemoveRow
+     * @type {Function}
+     */
+    clickRemoveRow: {
+        validator: A.Lang.isFunction,
+        value: function() {
+            return true;
+        }
+    },
+
     /**
      * Flag indicating if the feature of removing rows from layout is
      * enabled or not.

--- a/src/aui-layout/js/aui-layout-builder-remove-row.js
+++ b/src/aui-layout/js/aui-layout-builder-remove-row.js
@@ -71,6 +71,7 @@ LayoutBuilderRemoveRow.prototype = {
      * Fired after the `removable` attribute changes.
      *
      * @method _afterRemoveRowRemovableChange
+     * @params {EventFacade} event
      * @protected
      */
     _afterRemoveRowRemovableChange: function(event) {
@@ -149,7 +150,7 @@ LayoutBuilderRemoveRow.prototype = {
      * Inserts remove button before a specified row.
      *
      * @method _insertRemoveButtonBeforeRow
-     * @param {Node} layoutRow
+     * @param {A.LayoutRow} layoutRow
      * @param {Node} row
      * @protected
      */

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -275,14 +275,6 @@ A.LayoutBuilderResizeCol.prototype = {
             col1MinSize = col1.get('minSize'),
             col2MinSize = col2.get('minSize');
 
-        if (diff1 === 0 && col1value && (col1value.content !== undefined || col1value.get('content'))) {
-            return false;
-        }
-
-        if (diff2 === 0 && col2value && (col2value.content !== undefined || col2value.get('content'))) {
-            return false;
-        }
-
         if (col1.get('removable')) {
             col1MinSize = 0;
         }

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -473,10 +473,9 @@ A.LayoutBuilderResizeCol.prototype = {
      *
      * @method _resize
      * @param {Node} dragNode
-     * @param {Node} row
      * @protected
      */
-    _resize: function(dragNode, row) {
+    _resize: function(dragNode) {
         if (this._lastDropEnter) {
             this._handleBreakpointDrop(dragNode, this._lastDropEnter);
             this._lastDropEnter = null;

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -148,10 +148,10 @@ A.LayoutBuilderResizeCol.prototype = {
      */
     _afterDragMouseup: function(event) {
         var dragNode = event.target.get('node'),
-            rowNode = dragNode.ancestor(SELECTOR_ROW);
+            row = dragNode.ancestor(SELECTOR_ROW);
 
-        if (rowNode) {
-            this._hideBreakpoints(rowNode);
+        if (row) {
+            this._hideBreakpoints(row);
         }
     },
 

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -269,13 +269,11 @@ A.LayoutBuilderResizeCol.prototype = {
     _canDrop: function(dragNode, position) {
         var col1 = dragNode.getData('layout-col1'),
             col2 = dragNode.getData('layout-col2'),
-            col1value = col1.get('value'),
-            col2value = col2.get('value'),
             difference = position - dragNode.getData('layout-position'),
             diff1 = col1.get('size') + difference,
             diff2 = col2.get('size') - difference,
-            col1minSize = 0,
-            col2minSize = 0;
+            col1MinSize = col1.get('minSize'),
+            col2MinSize = col2.get('minSize');
 
         if (diff1 === 0 && col1value && (col1value.content !== undefined || col1value.get('content'))) {
             return false;
@@ -286,17 +284,14 @@ A.LayoutBuilderResizeCol.prototype = {
         }
 
         if (col1.get('removable')) {
-            col1minSize = 0;
+            col1MinSize = 0;
         }
 
         if (col2.get('removable')) {
-            col2minSize = 0;
+            col2MinSize = 0;
         }
 
-        if (diff1 < col1minSize) {
-            return false;
-        }
-        if (diff2 < col2minSize) {
+        if (diff1 < col1MinSize || diff2 < col2MinSize) {
             return false;
         }
 
@@ -340,17 +335,17 @@ A.LayoutBuilderResizeCol.prototype = {
         var col1 = dragNode.getData('layout-col1'),
             col2 = dragNode.getData('layout-col2'),
             difference = dropNode.getData('layout-position') - dragNode.getData('layout-position'),
-            col1newSize = col1.get('size') + difference,
-            col2newSize = col2.get('size') - difference;
+            col1NewSize = col1.get('size') + difference,
+            col2NewSize = col2.get('size') - difference;
 
-        col1.set('size', col1newSize);
-        col2.set('size', col2newSize);
+        col1.set('size', col1NewSize);
+        col2.set('size', col2NewSize);
 
-        if (col1.get('removable') && col1newSize === 0) {
+        if (col1.get('removable') && col1NewSize === 0) {
             this._removeCol(col1.get('node'));
         }
 
-        if (col2.get('removable') && col2newSize === 0) {
+        if (col2.get('removable') && col2NewSize === 0) {
             this._removeCol(col2.get('node'));
         }
 

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -3,8 +3,7 @@
  *
  * @module aui-layout-builder-resize-col
  */
-
-var BREAKPOINTS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+var BREAKPOINTS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     CSS_RESIZE_COL_BREAKPOINT = A.getClassName('layout', 'builder', 'resize', 'col', 'breakpoint'),
     CSS_RESIZE_COL_BREAKPOINT_LINE = A.getClassName('layout', 'builder', 'resize', 'col', 'breakpoint', 'line'),
     CSS_RESIZE_COL_BREAKPOINT_OVER = A.getClassName('layout', 'builder', 'resize', 'col', 'breakpoint', 'over'),
@@ -270,12 +269,34 @@ A.LayoutBuilderResizeCol.prototype = {
     _canDrop: function(dragNode, position) {
         var col1 = dragNode.getData('layout-col1'),
             col2 = dragNode.getData('layout-col2'),
-            difference = position - dragNode.getData('layout-position');
+            col1value = col1.get('value'),
+            col2value = col2.get('value'),
+            difference = position - dragNode.getData('layout-position'),
+            diff1 = col1.get('size') + difference,
+            diff2 = col2.get('size') - difference,
+            col1minSize = 0,
+            col2minSize = 0;
 
-        if (col1.get('size') + difference < col1.get('minSize')) {
+        if (diff1 === 0 && col1value && (col1value.content !== undefined || col1value.get('content'))) {
             return false;
         }
-        if (col2.get('size') - difference < col2.get('minSize')) {
+
+        if (diff2 === 0 && col2value && (col2value.content !== undefined || col2value.get('content'))) {
+            return false;
+        }
+
+        if (col1.get('removable')) {
+            col1minSize = 0;
+        }
+
+        if (col2.get('removable')) {
+            col2minSize = 0;
+        }
+
+        if (diff1 < col1minSize) {
+            return false;
+        }
+        if (diff2 < col2minSize) {
             return false;
         }
 
@@ -318,15 +339,18 @@ A.LayoutBuilderResizeCol.prototype = {
     _handleBreakpointDrop: function(dragNode, dropNode) {
         var col1 = dragNode.getData('layout-col1'),
             col2 = dragNode.getData('layout-col2'),
-            difference = dropNode.getData('layout-position') - dragNode.getData('layout-position');
+            difference = dropNode.getData('layout-position') - dragNode.getData('layout-position'),
+            col1newSize = col1.get('size') + difference,
+            col2newSize = col2.get('size') - difference;
 
-        col1.set('size', col1.get('size') + difference);
-        col2.set('size', col2.get('size') - difference);
-        if (col1.get('removable') && col1.get('size') === 0) {
+        col1.set('size', col1newSize);
+        col2.set('size', col2newSize);
+
+        if (col1.get('removable') && col1newSize === 0) {
             this._removeCol(col1.get('node'));
         }
 
-        if (col2.get('removable') && col2.get('size') === 0) {
+        if (col2.get('removable') && col2newSize === 0) {
             this._removeCol(col2.get('node'));
         }
 

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -95,6 +95,9 @@ A.LayoutBuilderResizeCol.prototype = {
             row = dragNode.ancestor(SELECTOR_ROW);
 
         this._resize(dragNode, row);
+        this._hideBreakpoints(row);
+        this._syncDragHandles();
+
         this.get('layout').normalizeColsHeight(new A.NodeList(row));
     },
 
@@ -275,15 +278,7 @@ A.LayoutBuilderResizeCol.prototype = {
             col1MinSize = col1.get('minSize'),
             col2MinSize = col2.get('minSize');
 
-        if (col1.get('removable')) {
-            col1MinSize = 0;
-        }
-
-        if (col2.get('removable')) {
-            col2MinSize = 0;
-        }
-
-        if (diff1 < col1MinSize || diff2 < col2MinSize) {
+        if (diff1 !== 0 && diff2 !== 0 && (diff1 < col1MinSize || diff2 < col2MinSize)) {
             return false;
         }
 
@@ -330,18 +325,26 @@ A.LayoutBuilderResizeCol.prototype = {
             col1NewSize = col1.get('size') + difference,
             col2NewSize = col2.get('size') - difference;
 
+        if (!col1.get('removable') && col1NewSize === 0) {
+            col1.fire('removalCanceled');
+            return;
+        }
+
+        if (!col2.get('removable') && col2NewSize === 0) {
+            col2.fire('removalCanceled');
+            return;
+        }
+
         col1.set('size', col1NewSize);
         col2.set('size', col2NewSize);
 
-        if (col1.get('removable') && col1NewSize === 0) {
+        if (col1NewSize === 0) {
             this._removeCol(col1.get('node'));
         }
 
-        if (col2.get('removable') && col2NewSize === 0) {
+        if (col2NewSize === 0) {
             this._removeCol(col2.get('node'));
         }
-
-        this._syncDragHandles();
     },
 
     /**
@@ -405,6 +408,8 @@ A.LayoutBuilderResizeCol.prototype = {
         row = this._lastDropEnter.ancestor(SELECTOR_ROW);
 
         this._resize(this._dragNode, row);
+        this._hideBreakpoints(row);
+        this._syncDragHandles();
     },
 
     /**
@@ -479,8 +484,6 @@ A.LayoutBuilderResizeCol.prototype = {
         else {
             dragNode.show();
         }
-
-        this._hideBreakpoints(row);
     },
 
     /**

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -3,14 +3,15 @@
  *
  * @module aui-layout-builder-resize-col
  */
-var BREAKPOINTS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+var ADD_COLUMN_ACTION = 'addColumn',
+    BREAKPOINTS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     CSS_RESIZE_COL_BREAKPOINT = A.getClassName('layout', 'builder', 'resize', 'col', 'breakpoint'),
     CSS_RESIZE_COL_BREAKPOINT_LINE = A.getClassName('layout', 'builder', 'resize', 'col', 'breakpoint', 'line'),
     CSS_RESIZE_COL_BREAKPOINT_OVER = A.getClassName('layout', 'builder', 'resize', 'col', 'breakpoint', 'over'),
-    CSS_RESIZE_COL_ENABLED = A.getClassName('layout', 'builder', 'resize', 'col', 'enabled'),
     CSS_RESIZE_COL_DRAGGABLE = A.getClassName('layout', 'builder', 'resize', 'col', 'draggable'),
     CSS_RESIZE_COL_DRAGGABLE_BORDER = A.getClassName('layout', 'builder', 'resize', 'col', 'draggable', 'border'),
     CSS_RESIZE_COL_DRAGGABLE_HANDLE = A.getClassName('layout', 'builder', 'resize', 'col', 'draggable', 'handle'),
+    CSS_RESIZE_COL_ENABLED = A.getClassName('layout', 'builder', 'resize', 'col', 'enabled'),
     MAX_SIZE = 12,
     SELECTOR_ROW = '.layout-row';
 
@@ -94,7 +95,12 @@ A.LayoutBuilderResizeCol.prototype = {
         var dragNode = this._delegateDrag.get('lastNode'),
             row = dragNode.ancestor(SELECTOR_ROW);
 
-        this._resize(dragNode);
+        if (dragNode.getData('layout-action') && dragNode.getData('layout-action') === 'addColumn') {
+            this._insertColumnAfterDropHandles(dragNode);
+        }
+        else {
+            this._resize(dragNode);
+        }
 
         if (row) {
             this._hideBreakpoints(row);
@@ -103,6 +109,8 @@ A.LayoutBuilderResizeCol.prototype = {
         this._syncDragHandles();
 
         this.get('layout').normalizeColsHeight(new A.NodeList(row));
+
+        dragNode.show();
     },
 
     /**
@@ -277,10 +285,24 @@ A.LayoutBuilderResizeCol.prototype = {
         var col1 = dragNode.getData('layout-col1'),
             col2 = dragNode.getData('layout-col2'),
             difference = position - dragNode.getData('layout-position'),
-            diff1 = col1.get('size') + difference,
-            diff2 = col2.get('size') - difference,
-            col1MinSize = col1.get('minSize'),
-            col2MinSize = col2.get('minSize');
+            diff1,
+            diff2,
+            col1MinSize,
+            col2MinSize;
+
+        if (dragNode.getData('layout-action') === ADD_COLUMN_ACTION) {
+            if ((col2 && difference < col2.get('size')) ||
+                (col1 && MAX_SIZE - col1.get('size') < position)) {
+                return true;
+            }
+
+            return false;
+        }
+
+        diff1 = col1.get('size') + difference,
+        diff2 = col2.get('size') - difference,
+        col1MinSize = col1.get('minSize'),
+        col2MinSize = col2.get('minSize');
 
         if (diff1 !== 0 && diff2 !== 0 && (diff1 < col1MinSize || diff2 < col2MinSize)) {
             return false;
@@ -364,6 +386,35 @@ A.LayoutBuilderResizeCol.prototype = {
         dropNodes.each(function(dropNode) {
             dropNode.setStyle('display', 'none');
         });
+    },
+
+    /**
+     * Add new column for the given layout row after drop handler.
+     *
+     * @method _insertColumnAfterDropHandles
+     * @param {A.LayoutRow} dragNode
+     * @protected
+     */
+     _insertColumnAfterDropHandles: function(dragNode){
+        var colLayoutPosition = this._lastDropEnter.getData('layout-position'),
+            dragPosition = dragNode.getData('layout-position'),
+            newCol = new A.LayoutCol(),
+            newColPosition,
+            newColumnSize = Math.abs(dragPosition - colLayoutPosition),
+            row = dragNode.ancestor(SELECTOR_ROW).getData('layout-row'),
+            rowColsLength = row.get('cols').length;
+
+        if (dragPosition === 0) {
+            newColPosition = 0;
+        }
+        else {
+            newColPosition = rowColsLength;
+        }
+
+        if (colLayoutPosition > 0 && colLayoutPosition < 12) {
+            newCol.set('size', newColumnSize);
+            row.addCol(newColPosition, newCol);
+        }
     },
 
     /**
@@ -456,7 +507,7 @@ A.LayoutBuilderResizeCol.prototype = {
      * @protected
      */
     _removeDragHandles: function() {
-        this._layoutContainer.all('.' + CSS_RESIZE_COL_DRAGGABLE).remove();
+        this._layoutContainer.all('.' + CSS_RESIZE_COL_DRAGGABLE + ':not(.layout-builder-add-col-draggable)').remove();
     },
 
     /**
@@ -537,12 +588,13 @@ A.LayoutBuilderResizeCol.prototype = {
      */
     _syncRowDragHandles: function(row) {
         var cols = row.get('cols'),
+            numberOfCols = cols.length,
             currentPos = 0,
             draggable,
             index,
             rowNode = row.get('node').one(SELECTOR_ROW);
 
-        for (index = 0; index < cols.length - 1; index++) {
+        for (index = 0; index < numberOfCols - 1; index++) {
             currentPos += cols[index].get('size');
 
             draggable = A.Node.create(this.TPL_RESIZE_COL_DRAGGABLE);

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -322,6 +322,14 @@ A.LayoutBuilderResizeCol.prototype = {
 
         col1.set('size', col1.get('size') + difference);
         col2.set('size', col2.get('size') - difference);
+console.log(col1.get('removable'), col1.get('size'));
+        if (col1.get('removable') && col1.get('size') === 0) {
+            this._removeCol(col1.get('node'));
+        }
+
+        if (col2.get('removable') && col2.get('size') === 0) {
+            this._removeCol(col2.get('node'));
+        }
 
         this._syncDragHandles();
     },

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -100,6 +100,7 @@ A.LayoutBuilderResizeCol.prototype = {
         }
         else {
             this._resize(dragNode);
+            this.get('layout').normalizeColsHeight(new A.NodeList(row));
         }
 
         if (row) {
@@ -107,8 +108,6 @@ A.LayoutBuilderResizeCol.prototype = {
         }
 
         this._syncDragHandles();
-
-        this.get('layout').normalizeColsHeight(new A.NodeList(row));
 
         dragNode.show();
     },
@@ -279,16 +278,17 @@ A.LayoutBuilderResizeCol.prototype = {
      * @method _canDrop
      * @param {Node} dragNode
      * @param {Number} position
+     * @return {Boolean}
      * @protected
      */
     _canDrop: function(dragNode, position) {
         var col1 = dragNode.getData('layout-col1'),
             col2 = dragNode.getData('layout-col2'),
-            difference = position - dragNode.getData('layout-position'),
+            col1MinSize,
+            col2MinSize,
             diff1,
             diff2,
-            col1MinSize,
-            col2MinSize;
+            difference = position - dragNode.getData('layout-position');
 
         if (dragNode.getData('layout-action') === ADD_COLUMN_ACTION) {
             if ((col2 && difference < col2.get('size')) ||
@@ -392,7 +392,7 @@ A.LayoutBuilderResizeCol.prototype = {
      * Add new column for the given layout row after drop handler.
      *
      * @method _insertColumnAfterDropHandles
-     * @param {A.LayoutRow} dragNode
+     * @param {Node} dragNode
      * @protected
      */
      _insertColumnAfterDropHandles: function(dragNode){
@@ -401,14 +401,13 @@ A.LayoutBuilderResizeCol.prototype = {
             newCol = new A.LayoutCol(),
             newColPosition,
             newColumnSize = Math.abs(dragPosition - colLayoutPosition),
-            row = dragNode.ancestor(SELECTOR_ROW).getData('layout-row'),
-            rowColsLength = row.get('cols').length;
+            row = dragNode.ancestor(SELECTOR_ROW).getData('layout-row');
 
         if (dragPosition === 0) {
             newColPosition = 0;
         }
         else {
-            newColPosition = rowColsLength;
+            newColPosition = row.get('cols').length;
         }
 
         if (colLayoutPosition > 0 && colLayoutPosition < 12) {

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -94,8 +94,12 @@ A.LayoutBuilderResizeCol.prototype = {
         var dragNode = this._delegateDrag.get('lastNode'),
             row = dragNode.ancestor(SELECTOR_ROW);
 
-        this._resize(dragNode, row);
-        this._hideBreakpoints(row);
+        this._resize(dragNode);
+
+        if (row) {
+            this._hideBreakpoints(row);
+        }
+
         this._syncDragHandles();
 
         this.get('layout').normalizeColsHeight(new A.NodeList(row));
@@ -407,8 +411,12 @@ A.LayoutBuilderResizeCol.prototype = {
 
         row = this._lastDropEnter.ancestor(SELECTOR_ROW);
 
-        this._resize(this._dragNode, row);
-        this._hideBreakpoints(row);
+        this._resize(this._dragNode);
+
+        if (row) {
+            this._hideBreakpoints(row);
+        }
+
         this._syncDragHandles();
     },
 

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -322,7 +322,6 @@ A.LayoutBuilderResizeCol.prototype = {
 
         col1.set('size', col1.get('size') + difference);
         col2.set('size', col2.get('size') - difference);
-console.log(col1.get('removable'), col1.get('size'));
         if (col1.get('removable') && col1.get('size') === 0) {
             this._removeCol(col1.get('node'));
         }

--- a/src/aui-layout/js/aui-layout-builder.js
+++ b/src/aui-layout/js/aui-layout-builder.js
@@ -156,8 +156,7 @@ A.LayoutBuilder = A.Base.create('layout-builder', A.Base, [
          */
         strings: {
             value: {
-                addColumn: 'Add Column',
-                removeRow: 'Remove Row'
+                addColumn: 'Add Column'
             },
             writeOnce: true
         }

--- a/src/aui-layout/js/aui-layout-builder.js
+++ b/src/aui-layout/js/aui-layout-builder.js
@@ -146,6 +146,20 @@ A.LayoutBuilder = A.Base.create('layout-builder', A.Base, [
             valueFn: function() {
                 return new A.Layout();
             }
+        },
+
+        /**
+         * Collection of strings used to label elements of the UI.
+         *
+         * @attribute strings
+         * @type {Object}
+         */
+        strings: {
+            value: {
+                addColumn: 'Add Column',
+                removeRow: 'Remove Row'
+            },
+            writeOnce: true
         }
     }
 });

--- a/src/aui-layout/js/aui-layout-col.js
+++ b/src/aui-layout/js/aui-layout-col.js
@@ -98,7 +98,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
             if (value.content) {
                 valueNode.append(value.content);
             }
-            else if (value.get('content')) {
+            else {
                 valueNode.append(value.get('content'));
 
                 this._contentEventHandle = value.after(
@@ -106,14 +106,6 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
                     A.bind(this._afterContentChange, this)
                 );
             }
-
-            else if (value.get('contentBox')) {
-                valueNode.append(value.get('contentBox'));
-            }
-            else {
-                valueNode.append(value);
-            }
-
         }
     }
 }, {

--- a/src/aui-layout/js/aui-layout-col.js
+++ b/src/aui-layout/js/aui-layout-col.js
@@ -26,7 +26,6 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
      */
     initializer: function() {
         this.after({
-            removableChange: this._afterRemovableChange,
             sizeChange: this._afterSizeChange,
             valueChange: this._afterValueChange
         });
@@ -43,22 +42,6 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
      */
     _afterContentChange: function() {
         this._uiSetValue(this.get('value'));
-    },
-
-    /**
-     * Fired after the `removable` attribute changes.
-     *
-     * @method _afterRemovableChange
-     * @param {EventFacade} event
-     * @protected
-     */
-    _afterRemovableChange: function(event) {
-        if (event.newVal) {
-            this.set('minSize', 0);
-        }
-        else {
-            this.set('minSize', 1);
-        }
     },
 
     /**

--- a/src/aui-layout/js/aui-layout-col.js
+++ b/src/aui-layout/js/aui-layout-col.js
@@ -98,7 +98,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
             if (value.content) {
                 valueNode.append(value.content);
             }
-            else {
+            else if (value.get('content')) {
                 valueNode.append(value.get('content'));
 
                 this._contentEventHandle = value.after(
@@ -106,6 +106,14 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
                     A.bind(this._afterContentChange, this)
                 );
             }
+
+            else if (value.get('contentBox')) {
+                valueNode.append(value.get('contentBox'));
+            }
+            else {
+                valueNode.append(value);
+            }
+
         }
     }
 }, {

--- a/src/aui-layout/js/aui-layout-col.js
+++ b/src/aui-layout/js/aui-layout-col.js
@@ -26,6 +26,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
      */
     initializer: function() {
         this.after({
+            removableChange: this._afterRemovableChange,
             sizeChange: this._afterSizeChange,
             valueChange: this._afterValueChange
         });
@@ -42,6 +43,22 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
      */
     _afterContentChange: function() {
         this._uiSetValue(this.get('value'));
+    },
+
+    /**
+     * Fired after the `removable` attribute changes.
+     *
+     * @method _afterRemovableChange
+     * @param {EventFacade} event
+     * @protected
+     */
+    _afterRemovableChange: function(event) {
+        if (event.newVal) {
+            this.set('minSize', 0);
+        }
+        else {
+            this.set('minSize', 1);
+        }
     },
 
     /**
@@ -79,7 +96,13 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
      * @protected
      */
     _uiSetSize: function(size) {
-        this.get('node').addClass(BOOTSTRAP_CLASS_PREFIX + size);
+        if (size > 0) {
+            this.get('node').addClass(BOOTSTRAP_CLASS_PREFIX + size);
+            this.get('node').show();
+        }
+        else {
+            this.get('node').hide();
+        }
     },
 
     /**
@@ -137,7 +160,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
          * @type {Number}
          */
         minSize: {
-            value: 1
+            value: 0
         },
 
         /**

--- a/src/aui-layout/js/aui-layout-col.js
+++ b/src/aui-layout/js/aui-layout-col.js
@@ -79,13 +79,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
      * @protected
      */
     _uiSetSize: function(size) {
-        if (size > 0) {
-            this.get('node').addClass(BOOTSTRAP_CLASS_PREFIX + size);
-            this.get('node').show();
-        }
-        else {
-            this.get('node').hide();
-        }
+        this.get('node').addClass(BOOTSTRAP_CLASS_PREFIX + size);
     },
 
     /**

--- a/src/aui-layout/js/aui-layout-col.js
+++ b/src/aui-layout/js/aui-layout-col.js
@@ -118,7 +118,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
 
         valueNode.empty();
         if (value) {
-            if (value.content) {
+            if (value.content !== undefined) {
                 valueNode.append(value.content);
             }
             else {
@@ -160,7 +160,7 @@ A.LayoutCol = A.Base.create('layout-col', A.Base, [], {
          * @type {Number}
          */
         minSize: {
-            value: 0
+            value: 1
         },
 
         /**

--- a/src/aui-layout/meta/aui-layout.json
+++ b/src/aui-layout/meta/aui-layout.json
@@ -79,7 +79,8 @@
         "requires": [
             "aui-node-base",
             "base-build"
-        ]
+        ],
+        "skinnable": true
     },
     "aui-layout-builder-move": {
         "requires": [

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-add-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-add-col-tests.js
@@ -54,70 +54,64 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
             }, config));
         },
 
-        'should add a col to a row when click on add col button': function() {
-            var addColButton,
-                col,
-                layout;
+        /**
+         * Simulates dragging the given dragHandle.
+         *
+         * @param {Y.Test.Case} test
+         * @param {Node} dragHandle
+         * @param {Array} position
+         * @param {Function} done
+         * @protected
+         */
+        _simulateDrag: function(test, dragHandle, position, done) {
+            var shim;
 
-            this._createLayoutBuilder();
+            dragHandle.simulate('mousedown');
+            test.wait(function() {
+                shim = Y.one('.yui3-dd-shim');
 
-            col = Y.one('.col-md-6');
-            addColButton = col.ancestor().one('.layout-builder-add-col');
-            addColButton.simulate('click');
+                if (position) {
+                    if (Y.Lang.isFunction(position)) {
+                        position = position();
+                    }
+                    shim.simulate('mousemove', {
+                        clientX: position[0],
+                        clientY: position[1]
+                    });
+                }
 
-            layout = this._layoutBuilder.get('layout');
-            Y.Assert.areEqual(layout.get('rows')[0].get('cols').length, 3);
+                dragHandle.simulate('mouseup');
+
+                if (done) {
+                    done();
+                }
+            }, Y.DD.DDM.get('clickTimeThresh') + 100);
         },
 
-        'should add a col at the beginning of a row when click on the left button': function() {
-            var addColButton,
-                container,
-                firstCol,
-                row;
-
-            this._createLayoutBuilder();
-
-            container = this._layoutBuilder.get('container');
-            row = container.one('.row');
-
-            firstCol = row.one('.col');
-
-            Y.Assert.isNotNull(firstCol.getData('layout-col').get('value'));
-
-            addColButton = row.one('.layout-builder-add-col-left');
-            addColButton.simulate('click');
-
-            firstCol = row.one('.col');
-
-            Y.Assert.isNull(firstCol.getData('layout-col').get('value'));
-        },
-
-        'should add a col at the end of a row when click on the right button': function() {
-            var addColButton,
-                container,
-                lastCol,
-                row;
-
-            this._createLayoutBuilder();
-
-            container = this._layoutBuilder.get('container');
-            row = container.one('.row');
-
-            lastCol = row.all('.col').last();
-
-            Y.Assert.isNotNull(lastCol.getData('layout-col').get('value'));
-
-            addColButton = row.one('.layout-builder-add-col-right');
-            addColButton.simulate('click');
-
-            lastCol = row.all('.col').last();
-
-            Y.Assert.isNull(lastCol.getData('layout-col').get('value'));
+        /**
+         * Simulates dragging the given dragHandle to the given breakpoint.
+         *
+         * @method _simulateDragToBreakpoint
+         * @param {Y.Test.Case} test
+         * @param {Node} dragHandle
+         * @param {Node} breakpoint
+         * @param {Function} done
+         * @protected
+         */
+        _simulateDragToBreakpoint: function(test, dragHandle, breakpoint, done) {
+            done = done || function(){};
+            this._simulateDrag(test, dragHandle, function() {
+                return [
+                    breakpoint.get('region').left,
+                    breakpoint.get('region').top
+                ];
+            }, done);
         },
 
         'should not append addCol button if row alreay has the maximum number of cols': function() {
             var cols,
-                firstRow;
+                firstRow,
+                i = 0;
 
             this._createLayoutBuilder();
 
@@ -125,8 +119,14 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
             cols = firstRow.get('cols');
 
             while (firstRow.get('cols').length < firstRow.get('maximumCols')) {
-                firstRow.addCol();
+                firstRow.addCol(i);
+                i++;
             }
+
+            Y.Assert.areEqual(firstRow.get('cols').length, firstRow.get('maximumCols'));
+
+            this._layoutBuilder.set('enableAddCols', false);
+            this._layoutBuilder.set('enableAddCols', true);
 
             Y.Assert.isNull(firstRow.get('node').one('.layout-builder-add-col'));
         },
@@ -146,75 +146,32 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
         },
 
         'should enable/disable adding columns dynamically': function() {
-            var addColButton,
+            var dragHandle,
+                breakpoint,
                 col,
-                layout;
+                layout,
+                instance = this;
 
-            this._createLayoutBuilder();
+            instance._createLayoutBuilder();
 
             col = Y.one('.col-md-6');
 
-            this._layoutBuilder.set('enableAddCols', false);
+            instance._layoutBuilder.set('enableAddCols', false);
 
-            addColButton = col.ancestor().one('.layout-builder-add-col');
-            Y.Assert.isNull(addColButton);
+            dragHandle = Y.one('.layout-builder-resize-col-draggable-handle.expand-left');
+            Y.Assert.isNull(dragHandle);
 
-            this._layoutBuilder.set('enableAddCols', true);
+            instance._layoutBuilder.set('enableAddCols', true);
 
-            addColButton = col.ancestor().one('.layout-builder-add-col');
-            Y.Assert.isNotNull(addColButton);
+            dragHandle = Y.one('.layout-builder-resize-col-draggable-handle.expand-left');
+            Y.Assert.isNotNull(dragHandle);
 
-            addColButton.simulate('click');
-            layout = this._layoutBuilder.get('layout');
-            Y.Assert.areEqual(layout.get('rows')[0].get('cols').length, 3);
-        },
+            breakpoint = col.ancestor().all('.layout-builder-resize-col-breakpoint').item(1);
 
-        'should add two add col buttons per row': function() {
-            var container,
-                row;
-
-            this._createLayoutBuilder();
-
-            container = this._layoutBuilder.get('container');
-            row = container.one('.row');
-
-            Y.Assert.areEqual(2, row.all('.layout-builder-add-col').size());
-        },
-
-        'should add addColButton to new rows': function() {
-            var addColButtons,
-                addRowArea,
-                container;
-
-            this._createLayoutBuilder();
-
-            container = this._layoutBuilder.get('container');
-            addColButtons = container.all('.layout-builder-add-col');
-
-            Y.Assert.areEqual(4, addColButtons.size());
-
-            addRowArea = container.one('.layout-builder-add-row-choose-row');
-            addRowArea.simulate('click');
-
-            addColButtons = container.all('.layout-builder-add-col');
-
-            Y.Assert.areEqual(6, addColButtons.size());
-        },
-
-        'should add a col when press enter on add col button': function() {
-            var addColButton,
-                row;
-
-            this._createLayoutBuilder();
-
-            addColButton = Y.one('.layout-builder-add-col');
-            row = addColButton.ancestor('.row');
-
-            Y.Assert.areEqual(2, row.getData('layout-row').get('cols').length);
-
-            addColButton.simulate('keypress', { keyCode: 13 });
-
-            Y.Assert.areEqual(3, row.getData('layout-row').get('cols').length);
+            instance._simulateDragToBreakpoint(instance, dragHandle, breakpoint, function() {
+                layout = instance._layoutBuilder.get('layout');
+                Y.Assert.areEqual(layout.get('rows')[0].get('cols').length, 3);
+            });
         },
 
         'should remove add col feature on smartphones': function() {
@@ -227,40 +184,50 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
 
             layout._set('isColumnMode', false);
 
-            addColButton = Y.one('.layout-builder-add-col');
+            addColButton = Y.one('.layout-builder-add-col-handle');
 
             Y.Assert.isNull(addColButton);
         },
 
         'should normalize cols height after add a new col': function() {
-            var addColButton,
-                layout;
+            var layout,
+                row,
+                dragHandle,
+                breakpoint;
 
             this._createLayoutBuilder();
 
             layout = this._layoutBuilder.get('layout');
+            row = layout.get('rows')[0];
+            dragHandle = row.get('node').one('.layout-builder-resize-col-draggable-handle.expand-right');
+            breakpoint = row.get('node').all('.layout-builder-resize-col-breakpoint').item(11);
 
             Y.Mock.expect(layout, {
                 args: [Y.Mock.Value.Object],
                 method: 'normalizeColsHeight'
             });
 
-            addColButton = Y.one('.layout-builder-add-col');
-            addColButton.simulate('click');
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {});
 
             Y.Mock.verify(layout);
         },
 
         'should not scroll when add a new col': function() {
-            var addColButton,
+            var breakpoint,
+                dragHandle,
+                instance = this,
                 layout,
+                row,
                 scrollPositionAfter,
                 scrollPositionBefore,
                 win = Y.config.win;
 
-            this._createLayoutBuilder();
+            instance._createLayoutBuilder();
 
-            layout = this._layoutBuilder.get('layout');
+            layout = instance._layoutBuilder.get('layout');
+            row = layout.get('rows')[0];
+            dragHandle = row.get('node').one('.layout-builder-resize-col-draggable-handle.expand-right');
+            breakpoint = row.get('node').all('.layout-builder-resize-col-breakpoint').item(11);
 
             for (var i = 0; i < 20; i++) {
                 layout.addRow();
@@ -268,16 +235,55 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
 
             win.scrollTo(0, Y.one('body').get('region').height);
 
-            this.wait(function() {
+            instance.wait(function() {
                 scrollPositionBefore = win.scrollY;
 
-                addColButton = Y.all('.layout-builder-add-col').last();
-                addColButton.simulate('click');
+                instance._simulateDragToBreakpoint(instance, dragHandle, breakpoint, function() {
+                    scrollPositionAfter = win.scrollY;
 
-                scrollPositionAfter = win.scrollY;
-
-                Y.Assert.areEqual(scrollPositionBefore, scrollPositionAfter);
+                    Y.Assert.areEqual(scrollPositionBefore, scrollPositionAfter);
+                });
             }, 100);
+        },
+
+        'should insert a new column on the left after drop the left draggable handle': function() {
+            var dragHandle,
+                breakpoint,
+                layout,
+                row;
+
+            this._createLayoutBuilder();
+
+            layout = this._layoutBuilder.get('layout');
+            row = layout.get('rows')[0];
+            dragHandle = row.get('node').one('.layout-builder-resize-col-draggable-handle.expand-left');
+            breakpoint = row.get('node').all('.layout-builder-resize-col-breakpoint').item(1);
+
+            Y.Assert.areEqual(row.get('cols').length, 2);
+
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
+                Y.Assert.areEqual(layout.get('rows')[0].get('cols').length, 3);
+            });
+        },
+
+        'should insert a new column on the right after drop the right draggable handle': function() {
+            var layout,
+                row,
+                dragHandle,
+                breakpoint;
+
+            this._createLayoutBuilder();
+
+            layout = this._layoutBuilder.get('layout');
+            row = layout.get('rows')[0];
+            dragHandle = row.get('node').one('.layout-builder-resize-col-draggable-handle.expand-right');
+            breakpoint = row.get('node').all('.layout-builder-resize-col-breakpoint').item(11);
+
+            Y.Assert.areEqual(row.get('cols').length, 2);
+
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
+                Y.Assert.areEqual(layout.get('rows')[0].get('cols').length, 3);
+            });
         }
     }));
 

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-add-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-add-col-tests.js
@@ -108,6 +108,26 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
             }, done);
         },
 
+        'should add addColButton to new rows': function() {
+            var addColButtons,
+                addRowArea,
+                container;
+
+            this._createLayoutBuilder();
+
+            container = this._layoutBuilder.get('container');
+            addColButtons = container.all('.layout-builder-add-col-handle');
+
+            Y.Assert.areEqual(4, addColButtons.size());
+
+            addRowArea = container.one('.layout-builder-add-row-choose-row');
+            addRowArea.simulate('click');
+
+            addColButtons = container.all('.layout-builder-add-col-handle');
+
+            Y.Assert.areEqual(6, addColButtons.size());
+        },
+
         'should not append addCol button if row alreay has the maximum number of cols': function() {
             var cols,
                 firstRow,
@@ -118,15 +138,12 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
             firstRow = this._layoutBuilder.get('layout').get('rows')[0];
             cols = firstRow.get('cols');
 
-            while (firstRow.get('cols').length < firstRow.get('maximumCols')) {
+            while (i < firstRow.get('maximumCols') + 2) {
                 firstRow.addCol(i);
-                i++;
+                i ++;
             }
 
             Y.Assert.areEqual(firstRow.get('cols').length, firstRow.get('maximumCols'));
-
-            this._layoutBuilder.set('enableAddCols', false);
-            this._layoutBuilder.set('enableAddCols', true);
 
             Y.Assert.isNull(firstRow.get('node').one('.layout-builder-add-col'));
         },
@@ -190,10 +207,10 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
         },
 
         'should normalize cols height after add a new col': function() {
-            var layout,
-                row,
+            var breakpoint,
                 dragHandle,
-                breakpoint;
+                layout,
+                row;
 
             this._createLayoutBuilder();
 
@@ -207,9 +224,9 @@ YUI.add('aui-layout-builder-add-col-tests', function(Y) {
                 method: 'normalizeColsHeight'
             });
 
-            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {});
-
-            Y.Mock.verify(layout);
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
+                Y.Mock.verify(layout); 
+            });
         },
 
         'should not scroll when add a new col': function() {

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-remove-row-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-remove-row-tests.js
@@ -119,6 +119,32 @@ YUI.add('aui-layout-builder-remove-row-tests', function(Y) {
             Assert.isNull(button);
         },
 
+        'should remove a row on remove button clicked only if `clickRemoveRow` attribute returns true': function() {
+            var layout = new Y.Layout({
+                rows: [
+                    new Y.LayoutRow(),
+                    new Y.LayoutRow()
+                ]
+            });
+
+            this.layoutBuilder.set('layout', layout);
+
+            Assert.areEqual(2, Y.all('.layout-row-container-row').size());
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Assert.areEqual(1, Y.all('.layout-row-container-row').size());
+
+            this.layoutBuilder.set('clickRemoveRow', function() { return false; });
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Assert.areEqual(1, Y.all('.layout-row-container-row').size());
+
+            this.layoutBuilder.set('clickRemoveRow', function() { return true; });
+
+            Y.one('.layout-builder-remove-row-button').simulate('click');
+            Assert.areEqual(0, Y.all('.layout-row-container-row').size());
+        },
+
         'should not add remove row button if a row is not removable': function() {
             var layout = new Y.Layout({
                 rows: [

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -514,6 +514,54 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             });
         },
 
+        'should not destroy unremovable third column from left': function() {
+            var row = Y.one('.row'),
+                col = row.all('.col').item(2),
+                layoutCol = col.getData('layout-col'),
+                dragHandle,
+                breakpoint,
+                canceled;
+
+            layoutCol.set('removable', false);
+
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(1);
+
+            breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(9);
+
+            layoutCol.on('removalCanceled', function() {
+                canceled = true;
+            });
+
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
+                Assert.areEqual(3, col.getData('layout-col').get('size'));
+                Assert.areEqual(true, canceled);
+            });
+        },
+
+        'should not destroy unremovable third column from right': function() {
+            var row = Y.one('.row'),
+                col = row.all('.col').item(2),
+                layoutCol = col.getData('layout-col'),
+                dragHandle,
+                breakpoint,
+                canceled;
+
+            layoutCol.set('removable', false);
+
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
+
+            breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(6);
+
+            layoutCol.on('removalCanceled', function() {
+                canceled = true;
+            });
+
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
+                Assert.areEqual(3, col.getData('layout-col').get('size'));
+                Assert.areEqual(true, canceled);
+            });
+        },
+
         'should toggle breakpoints visibility when keypress on draghandle': function() {
             var dragHandle,
                 row = Y.all('.row').item(1);

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -321,7 +321,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             Y.Assert.areEqual(0, breakpoints.length);
         },
 
-        'should not insert layout grid if a row is full of cols': function() {
+        'should have a number of handles consistent with the number of removable rows': function() {
             var dragHandles,
                 firstRow;
 
@@ -330,12 +330,13 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             while (firstRow.get('cols').length < firstRow.get('maximumCols')) {
                     firstRow.addCol(undefined, new Y.LayoutCol({
                     value: { content: '' },
+                    removable: false,
                     size: 1
                 }));
             }
 
             dragHandles = firstRow.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE + ':not(.hide)');
-            Assert.areEqual(0, dragHandles.size());
+            Assert.areEqual(4, dragHandles.size());
         },
 
         'should resize columns when dropping handle on breakpoint': function() {

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -359,6 +359,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
             breakpoint = row.get('node').all('.' + CSS_RESIZE_COL_BREAKPOINT).item(3);
+
             this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
                 dragNode = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE);
                 breakpoint = row.get('node').one('.' + CSS_RESIZE_COL_BREAKPOINT);
@@ -386,6 +387,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 row = this._layoutBuilder.get('layout').get('rows')[1];
 
             dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+
             this._simulateDrag(this, dragHandle, undefined, function() {
                 dragNode = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE);
                 Y.Assert.areEqual(6, dragNode.getData('layout-position'));
@@ -525,7 +527,6 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             layoutCol.set('removable', false);
 
             dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(1);
-
             breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(9);
 
             layoutCol.on('removalCanceled', function() {
@@ -549,7 +550,6 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             layoutCol.set('removable', false);
 
             dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
-
             breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(6);
 
             layoutCol.on('removalCanceled', function() {

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -213,12 +213,12 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
         'should append drag handlers for all borders that can be dragged': function() {
             var rows = this._layoutBuilder.get('layout').get('rows');
 
-            Assert.areEqual(3, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[1], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[2], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[3], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(2, this._getVisibleRowNodes(rows[4], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(2, this._getVisibleRowNodes(rows[5], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(5, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[1], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[2], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[3], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(4, this._getVisibleRowNodes(rows[4], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(4, this._getVisibleRowNodes(rows[5], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
         },
 
         'should update drag handles when a new layout is set': function() {
@@ -256,8 +256,8 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             ]}));
             rows = this._layoutBuilder.get('layout').get('rows');
 
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(2, this._getVisibleRowNodes(rows[1], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(4, this._getVisibleRowNodes(rows[1], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
         },
 
         'should update drag handles when they layout rows change': function() {
@@ -277,7 +277,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             })),
             rows = this._layoutBuilder.get('layout').get('rows');
 
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
         },
 
         'should update drag handles when they layout cols change': function() {
@@ -288,7 +288,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 size: 1
             }));
 
-            Assert.areEqual(2, this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(4, this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
         },
 
         'should insert layout grid on drag handle\'s click': function() {
@@ -298,7 +298,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             // The second row has 2 columns with size 6 each.
             row = this._layoutBuilder.get('layout').get('rows')[1];
-            dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+            dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
             dragHandle.simulate('mousedown');
 
             breakpoints = this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_BREAKPOINT);
@@ -310,7 +310,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             // The fifth row has 3 columns with size 4 each.
             row = this._layoutBuilder.get('layout').get('rows')[4];
-            dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+            dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
             dragHandle.simulate('mousedown');
 
             breakpoints = this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_BREAKPOINT);
@@ -335,16 +335,19 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
         'should have a number of handles consistent with the number of rows': function() {
             var dragHandles,
-                firstRow;
+                firstRow,
+                i = 0;
 
             firstRow = this._layoutBuilder.get('layout').get('rows')[0];
 
             while (firstRow.get('cols').length < firstRow.get('maximumCols')) {
-                    firstRow.addCol(undefined, new Y.LayoutCol({
+                    firstRow.addCol(i, new Y.LayoutCol({
                     value: { content: '' },
                     removable: false,
                     size: 1
                 }));
+
+                i++;
             }
 
             dragHandles = firstRow.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE + ':not(.hide)');
@@ -357,11 +360,11 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 dragNode,
                 row = this._layoutBuilder.get('layout').get('rows')[1];
 
-            dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+            dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
             breakpoint = row.get('node').all('.' + CSS_RESIZE_COL_BREAKPOINT).item(3);
 
             this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
-                dragNode = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE);
+                dragNode = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE).item(2);
                 breakpoint = row.get('node').one('.' + CSS_RESIZE_COL_BREAKPOINT);
                 Y.Assert.areEqual(3, dragNode.getData('layout-position'));
                 Y.Assert.areEqual(3, row.get('cols')[0].get('size'));
@@ -373,7 +376,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             var dragHandle,
                 row = this._layoutBuilder.get('layout').get('rows')[1];
 
-            dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+            dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
 
             this._simulateDrag(this, dragHandle, [1000, 10], function() {
                 Y.Assert.areEqual(6, row.get('cols')[0].get('size'));
@@ -386,10 +389,10 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 dragNode,
                 row = this._layoutBuilder.get('layout').get('rows')[1];
 
-            dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+            dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
 
             this._simulateDrag(this, dragHandle, undefined, function() {
-                dragNode = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE);
+                dragNode = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE).item(2);
                 Y.Assert.areEqual(6, dragNode.getData('layout-position'));
                 Y.Assert.areEqual(6, row.get('cols')[0].get('size'));
                 Y.Assert.areEqual(6, row.get('cols')[1].get('size'));
@@ -428,12 +431,12 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             this._layoutBuilder.set('enableResizeCols', true);
 
-            Assert.areEqual(3, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[1], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[2], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(1, this._getVisibleRowNodes(rows[3], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(2, this._getVisibleRowNodes(rows[4], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
-            Assert.areEqual(2, this._getVisibleRowNodes(rows[5], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(5, this._getVisibleRowNodes(rows[0], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[1], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[2], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(3, this._getVisibleRowNodes(rows[3], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(4, this._getVisibleRowNodes(rows[4], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
+            Assert.areEqual(4, this._getVisibleRowNodes(rows[5], '.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).length);
         },
 
         'should resize columns': function() {
@@ -443,7 +446,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 row = Y.all('.row').item(1);
 
             col = row.one('.col');
-            dragHandle = row.one('.layout-builder-resize-col-draggable-handle');
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
 
             Assert.areEqual(6, col.getData('layout-col').get('size'));
 
@@ -466,7 +469,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             });
 
             col = row.one('.col');
-            dragHandle = row.one('.layout-builder-resize-col-draggable-handle');
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
 
             Assert.areEqual(6, col.getData('layout-col').get('size'));
 
@@ -479,40 +482,65 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
         },
 
         'should destroy removable first column': function() {
-            var row = Y.one('.row'),
-                cols = row.all('.col'),
+            var breakpoint,
+                breakpointToAdding,
+                cols,
                 dragHandle,
-                breakpoint,
-                addColButton = row.one('.layout-builder-add-col');
+                handleAddColumn,
+                layout = this._layoutBuilder.get('layout'),
+                row = Y.one('.row'),
+                self = this;
+
+            cols = row.all('.col');
+
+            this._layoutBuilder.set('enableAddCols', true);
+
+            handleAddColumn = row.one('.layout-builder-resize-col-draggable-handle.expand-left');
+            breakpointToAdding = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(1);
 
             Assert.areEqual(true, cols.item(0).getData('layout-col').get('removable'));
 
-            addColButton.simulate('click');
+            this._simulateDragToBreakpoint(this, handleAddColumn, breakpointToAdding, function() {
+                dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
+                breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(0);
 
-            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(0);
-            breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(0);
+                Assert.areEqual(layout.get('rows')[0].get('cols').length, 5);
 
-            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
-                Assert.areEqual(3, cols.item(0).getData('layout-col').get('size'));
+                self._simulateDragToBreakpoint(self, dragHandle, breakpoint, function() {
+                    Assert.areEqual(layout.get('rows')[0].get('cols').length, 4);
+                });
             });
         },
 
         'should destroy removable second column': function() {
-            var row = Y.one('.row'),
-                cols = row.all('.col'),
+            var breakpoint,
+                breakpointToAdding,
+                cols,
                 dragHandle,
-                breakpoint,
-                addColButton = row.all('.layout-builder-add-col').item(1);
+                handleAddColumn,
+                layout = this._layoutBuilder.get('layout'),
+                row = Y.one('.row'),
+                instance = this;
+
+            cols = row.all('.col');
+
+            this._layoutBuilder.set('enableAddCols', true);
 
             Assert.areEqual(true, cols.item(0).getData('layout-col').get('removable'));
+            Assert.areEqual(4, cols._nodes.length);
 
-            addColButton.simulate('click');
+            handleAddColumn = row.one('.layout-builder-resize-col-draggable-handle.expand-right');
+            breakpointToAdding = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(11);
 
-            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(3);
-            breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(12);
+            instance._simulateDragToBreakpoint(instance, handleAddColumn, breakpointToAdding, function() {
+                dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(5);
+                breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(12);
 
-            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
-                Assert.areEqual(3, cols.item(0).getData('layout-col').get('size'));
+                Assert.areEqual(layout.get('rows')[0].get('cols').length, 5);
+
+                instance._simulateDragToBreakpoint(instance, dragHandle, breakpoint, function() {
+                    Assert.areEqual(layout.get('rows')[0].get('cols').length, 4);
+                }); 
             });
         },
 
@@ -526,7 +554,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             layoutCol.set('removable', false);
 
-            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(1);
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(3);
             breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(9);
 
             layoutCol.on('removalCanceled', function() {
@@ -549,7 +577,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             layoutCol.set('removable', false);
 
-            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(4);
             breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(6);
 
             layoutCol.on('removalCanceled', function() {
@@ -566,7 +594,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             var dragHandle,
                 row = Y.all('.row').item(1);
 
-            dragHandle = row.one('.layout-builder-resize-col-draggable-handle');
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(2);
 
             Assert.areEqual('none', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
 
@@ -622,6 +650,22 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             breakpoint = row.get('node').one('.' + CSS_RESIZE_COL_BREAKPOINT);
             this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
                 Y.Mock.verify(layout);
+            });
+        },
+
+        'should cancel add col': function() {
+            var breakpoint,
+                dragHandle,
+                layout = this._layoutBuilder.get('layout'),
+                row = this._layoutBuilder.get('layout').get('rows')[1];
+
+            dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);
+            breakpoint = row.get('node').one('.' + CSS_RESIZE_COL_BREAKPOINT);
+
+            Assert.areEqual(2, row.get('cols').length);
+            
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint, function() {
+                Assert.areEqual(2, row.get('cols').length);
             });
         }
     }));

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -543,7 +543,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             Y.Assert.isNull(resizeColDraggable);
         },
 
-        'should normalize cols\' height after resize a column': function() {
+        'should normalize cols\' height after column resize': function() {
             var breakpoint,
                 dragHandle,
                 layout = this._layoutBuilder.get('layout'),

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -336,18 +336,18 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
         'should have a number of handles consistent with the number of rows': function() {
             var dragHandles,
                 firstRow,
-                i = 0;
+                index = 0;
 
             firstRow = this._layoutBuilder.get('layout').get('rows')[0];
 
             while (firstRow.get('cols').length < firstRow.get('maximumCols')) {
-                    firstRow.addCol(i, new Y.LayoutCol({
+                    firstRow.addCol(index, new Y.LayoutCol({
                     value: { content: '' },
                     removable: false,
                     size: 1
                 }));
 
-                i++;
+                index++;
             }
 
             dragHandles = firstRow.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE + ':not(.hide)');
@@ -489,7 +489,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 handleAddColumn,
                 layout = this._layoutBuilder.get('layout'),
                 row = Y.one('.row'),
-                self = this;
+                instance = this;
 
             cols = row.all('.col');
 
@@ -506,7 +506,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
                 Assert.areEqual(layout.get('rows')[0].get('cols').length, 5);
 
-                self._simulateDragToBreakpoint(self, dragHandle, breakpoint, function() {
+                instance._simulateDragToBreakpoint(instance, dragHandle, breakpoint, function() {
                     Assert.areEqual(layout.get('rows')[0].get('cols').length, 4);
                 });
             });
@@ -653,10 +653,9 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             });
         },
 
-        'should cancel add col': function() {
+        'should cancel add col after drag the left add handle to the first breakpoint': function() {
             var breakpoint,
                 dragHandle,
-                layout = this._layoutBuilder.get('layout'),
                 row = this._layoutBuilder.get('layout').get('rows')[1];
 
             dragHandle = row.get('node').one('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE);

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -338,7 +338,10 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             firstRow = this._layoutBuilder.get('layout').get('rows')[0];
 
             while (firstRow.get('cols').length < firstRow.get('maximumCols')) {
-                firstRow.addCol();
+                    firstRow.addCol(undefined, new Y.LayoutCol({
+                    value: { content: '' },
+                    size: 1
+                }));
             }
 
             dragHandles = firstRow.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE + ':not(.hide)');
@@ -429,7 +432,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
         'should resize columns': function() {
             var col,
                 dragHandle,
-                firstBreakpointLine,
+                secondBreakpointLine,
                 row = Y.all('.row').item(1);
 
             col = row.one('.col');
@@ -439,12 +442,69 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             dragHandle.simulate('keypress', { keyCode: 13 });
 
-            firstBreakpointLine = row.one('.layout-builder-resize-col-breakpoint-line');
-            firstBreakpointLine.simulate('keypress', { keyCode: 13 });
-
-            col = row.one('.col');
+            secondBreakpointLine = row.all('.layout-builder-resize-col-breakpoint-line').item(1);
+            secondBreakpointLine.simulate('keypress', { keyCode: 13 });
 
             Assert.areEqual(1, col.getData('layout-col').get('size'));
+        },
+
+        'should resize unremovable columns': function() {
+            var col,
+                dragHandle,
+                secondBreakpointLine,
+                row = Y.all('.row').item(1);
+
+            row.all('.col').each(function(col) {
+                col.getData('layout-col').set('removable', false);
+            });
+
+            col = row.one('.col');
+            dragHandle = row.one('.layout-builder-resize-col-draggable-handle');
+
+            Assert.areEqual(6, col.getData('layout-col').get('size'));
+
+            dragHandle.simulate('keypress', { keyCode: 13 });
+
+            secondBreakpointLine = row.all('.layout-builder-resize-col-breakpoint-line').item(1);
+            secondBreakpointLine.simulate('keypress', { keyCode: 13 });
+
+            Assert.areEqual(1, col.getData('layout-col').get('size'));
+        },
+
+        'should destroy removable first column': function() {
+            var row = Y.one('.row'),
+                col = row.one('.col'),
+                dragHandle,
+                breakpoint,
+                addColButton = row.one('.layout-builder-add-col');
+
+            Assert.areEqual(true, col.getData('layout-col').get('removable'));
+
+            addColButton.simulate('click');
+
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(0);
+            breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(0);
+
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint);
+            Assert.areEqual(5, col.getData('layout-col').get('size'));
+        },
+
+        'should destroy removable second column': function() {
+            var row = Y.one('.row'),
+                col = row.one('.col'),
+                dragHandle,
+                breakpoint,
+                addColButton = row.all('.layout-builder-add-col').item(1);
+
+            Assert.areEqual(true, col.getData('layout-col').get('removable'));
+
+            addColButton.simulate('click');
+
+            dragHandle = row.all('.layout-builder-resize-col-draggable-handle').item(3);
+            breakpoint = row.all('.' + CSS_RESIZE_COL_BREAKPOINT).item(12);
+
+            this._simulateDragToBreakpoint(this, dragHandle, breakpoint);
+            Assert.areEqual(5, col.getData('layout-col').get('size'));
         },
 
         'should toggle breakpoints visibility when keypress on draghandle': function() {
@@ -453,13 +513,13 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
 
             dragHandle = row.one('.layout-builder-resize-col-draggable-handle');
 
-            Assert.areEqual('none', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('none', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
 
             dragHandle.simulate('keypress', { keyCode: 13 });
-            Assert.areEqual('block', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('block', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
 
             dragHandle.simulate('keypress', { keyCode: 13 });
-            Assert.areEqual('none', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('none', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
         },
 
         'should not show grid breakpoints when clicking drag handle with a button other than left': function() {
@@ -467,16 +527,16 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 row = Y.all('.row').item(1);
 
             dragHandle = row.one('.layout-builder-resize-col-draggable-handle');
-            Assert.areEqual('none', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('none', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
 
             dragHandle.simulate('mousedown', { button: 1 });
-            Assert.areEqual('none', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('none', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
 
             dragHandle.simulate('mousedown', { button: 2 });
-            Assert.areEqual('none', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('none', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
 
             dragHandle.simulate('mousedown', { button: 0 });
-            Assert.areEqual('block', row.one('.layout-builder-resize-col-breakpoint').getStyle('display'));
+            Assert.areEqual('block', row.all('.layout-builder-resize-col-breakpoint').item(1).getStyle('display'));
         },
 
         'should remove resize col feature on smartphones': function() {

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -290,18 +290,11 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             dragHandle.simulate('mousedown');
 
             breakpoints = this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_BREAKPOINT);
-            Y.Assert.areEqual(11, breakpoints.length);
-            Y.Assert.areEqual(1, breakpoints[0].getData('layout-position'));
-            Y.Assert.areEqual(2, breakpoints[1].getData('layout-position'));
-            Y.Assert.areEqual(3, breakpoints[2].getData('layout-position'));
-            Y.Assert.areEqual(4, breakpoints[3].getData('layout-position'));
-            Y.Assert.areEqual(5, breakpoints[4].getData('layout-position'));
-            Y.Assert.areEqual(6, breakpoints[5].getData('layout-position'));
-            Y.Assert.areEqual(7, breakpoints[6].getData('layout-position'));
-            Y.Assert.areEqual(8, breakpoints[7].getData('layout-position'));
-            Y.Assert.areEqual(9, breakpoints[8].getData('layout-position'));
-            Y.Assert.areEqual(10, breakpoints[9].getData('layout-position'));
-            Y.Assert.areEqual(11, breakpoints[10].getData('layout-position'));
+            Y.Assert.areEqual(13, breakpoints.length);
+
+            Y.Array.each(breakpoints, function(breakpoint, position) {
+                Y.Assert.areEqual(position, breakpoint.getData('layout-position'));
+            });
 
             // The fifth row has 3 columns with size 4 each.
             row = this._layoutBuilder.get('layout').get('rows')[4];
@@ -309,14 +302,11 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             dragHandle.simulate('mousedown');
 
             breakpoints = this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_BREAKPOINT);
-            Y.Assert.areEqual(7, breakpoints.length);
-            Y.Assert.areEqual(1, breakpoints[0].getData('layout-position'));
-            Y.Assert.areEqual(2, breakpoints[1].getData('layout-position'));
-            Y.Assert.areEqual(3, breakpoints[2].getData('layout-position'));
-            Y.Assert.areEqual(4, breakpoints[3].getData('layout-position'));
-            Y.Assert.areEqual(5, breakpoints[4].getData('layout-position'));
-            Y.Assert.areEqual(6, breakpoints[5].getData('layout-position'));
-            Y.Assert.areEqual(7, breakpoints[6].getData('layout-position'));
+            Y.Assert.areEqual(9, breakpoints.length);
+
+            Y.Array.each(breakpoints, function(breakpoint, position) {
+                Y.Assert.areEqual(position, breakpoint.getData('layout-position'));
+            });
         },
 
         'should not insert layout grid for borders without handles': function() {

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-tests.js
@@ -88,16 +88,6 @@ YUI.add('aui-layout-builder-tests', function(Y) {
             Assert.areEqual(row.get('cols').length, 3);
         },
 
-        'should remove a col from a row': function() {
-            var row = layout.get('rows')[1];
-
-            Assert.areEqual(row.get('cols').length, 2);
-
-            row.removeCol(1);
-
-            Assert.areEqual(row.get('cols').length, 1);
-        },
-
         'should add a row to layout': function() {
             Assert.areEqual(container.all('.row').size(), 2);
             layout.addRow(4);

--- a/src/aui-layout/tests/unit/js/aui-layout-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-col-tests.js
@@ -45,7 +45,7 @@ YUI.add('aui-layout-col-tests', function(Y) {
             Assert.areEqual(12, layoutCol.get('size'));
         },
 
-        'should set minimum size if it\'s size is lower than the minimum': function() {
+        'should set minimum size if its size is lower than the minimum': function() {
             var layoutCol = new Y.LayoutCol({
                 size: -1
             });

--- a/src/aui-layout/tests/unit/js/aui-layout-row-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-row-tests.js
@@ -8,12 +8,18 @@ YUI.add('aui-layout-row-tests', function(Y) {
         name: 'Layout Row Tests',
 
         setUp: function() {
+            this._createLayoutBuilder();
+        },
+
+        _createLayoutBuilder: function(config) {
+            var layoutRow;
+            
             col = new Y.LayoutCol({
                 size: 4,
                 value: {content: 'foo'}
             });
 
-            this.layoutRow = new Y.LayoutRow({
+            layoutRow = {
                 cols: [
                     col,
                     new Y.LayoutCol({
@@ -25,7 +31,9 @@ YUI.add('aui-layout-row-tests', function(Y) {
                         value: { content: 'baz' }
                     })
                 ]
-            });
+            };
+
+            this.layoutRow = new Y.LayoutRow(Y.merge(layoutRow, config));
         },
 
         tearDown: function() {
@@ -98,23 +106,36 @@ YUI.add('aui-layout-row-tests', function(Y) {
 
         'should add a col passing a reference': function() {
             var childNumber,
-                row = this.layoutRow;
+                row;
 
+            this._createLayoutBuilder({
+                cols: []
+            });
+
+            row = this.layoutRow;
             childNumber = row.get('cols').length;
-            Assert.areEqual(3, childNumber);
+
+            Assert.areEqual(childNumber, 1);
 
             row.addCol(0, col);
+            
             childNumber = row.get('cols').length;
-
-            Assert.areEqual(4, childNumber);
+            Assert.areEqual(childNumber, 2);
         },
 
         'should not add col if max is reached': function() {
-            var currentColsSize = this.layoutRow.get('cols').length,
-                maximumCols = this.layoutRow.get('maximumCols');
+            var currentColsSize,
+                maximumCols;
+
+            this._createLayoutBuilder({
+                cols: []
+            });
+
+            currentColsSize = this.layoutRow.get('cols').length;
+            maximumCols = this.layoutRow.get('maximumCols');
 
             for (var i = currentColsSize; i <= maximumCols; i++) {
-                this.layoutRow.addCol();
+                this.layoutRow.addCol(i - 1);
             }
 
             Assert.areEqual(maximumCols, this.layoutRow.get('cols').length);
@@ -249,7 +270,97 @@ YUI.add('aui-layout-row-tests', function(Y) {
             Assert.areEqual(3, layoutRow.get('cols').length);
             Assert.isTrue(Y.instanceOf(layoutRow.get('cols')[0], Y.LayoutCol));
             Assert.areEqual('foo', layoutRow.get('cols')[0].get('value').content);
-        }
+        },
+
+        'should be able to add a col without passing index': function() {
+            var childNumber,
+                row = this.layoutRow,
+                col = new Y.LayoutCol({
+                    size: 1,
+                    value: {content: 'foo'}
+                });
+
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 3);
+
+            row.addCol(col);
+            
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 4);
+        },
+
+        'should be able to add a col passing a index up than 11': function() {
+            var childNumber,
+                row = this.layoutRow;
+
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 3);
+
+            row.addCol(20);
+            
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 4);
+        },
+
+        'should be able to add a col between neighbors': function() {
+            var childNumber,
+                row = this.layoutRow,
+                newCol = new Y.LayoutCol({
+                    size: 1
+                });
+
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 3);
+
+            row.addCol(1, newCol);
+            
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 4);
+            Assert.areEqual(12, row._getSize(row.get('cols')));
+        },
+
+        'should remove a col between neighbors': function() {
+            var layoutRow,
+                cols;
+
+            this._createLayoutBuilder( {
+                cols: [
+                    new Y.LayoutCol({
+                        size: 1,
+                        value: { content: 'bar' }
+                    }),
+                    new Y.LayoutCol({
+                        size: 10,
+                        value: { content: 'baz' }
+                    }),
+                    new Y.LayoutCol({
+                        size: 1,
+                        value: { content: 'baz' }
+                    })
+                ]
+            });
+
+            layoutRow = this.layoutRow;
+            layoutRow.removeCol(1);
+
+            cols = layoutRow.get('cols');
+
+            Y.Assert.areEqual(2, cols.length);
+            Y.Assert.areEqual(6, cols[0].get('size'));
+        },
+
+        'should remove the last col from a row': function() {
+            var childNumber,
+                row = this.layoutRow;
+
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 3);
+
+            row.removeCol(2);
+            
+            childNumber = row.get('cols').length;
+            Assert.areEqual(childNumber, 2);
+        },
     }));
 
     Y.Test.Runner.add(suite);

--- a/src/aui-layout/tests/unit/js/aui-layout-row-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-row-tests.js
@@ -8,10 +8,10 @@ YUI.add('aui-layout-row-tests', function(Y) {
         name: 'Layout Row Tests',
 
         setUp: function() {
-            this._createLayoutBuilder();
+            this._createLayoutCol();
         },
 
-        _createLayoutBuilder: function(config) {
+        _createLayoutCol: function(config) {
             var layoutRow;
             
             col = new Y.LayoutCol({
@@ -108,7 +108,7 @@ YUI.add('aui-layout-row-tests', function(Y) {
             var childNumber,
                 row;
 
-            this._createLayoutBuilder({
+            this._createLayoutCol({
                 cols: []
             });
 
@@ -127,15 +127,15 @@ YUI.add('aui-layout-row-tests', function(Y) {
             var currentColsSize,
                 maximumCols;
 
-            this._createLayoutBuilder({
+            this._createLayoutCol({
                 cols: []
             });
 
             currentColsSize = this.layoutRow.get('cols').length;
             maximumCols = this.layoutRow.get('maximumCols');
 
-            for (var i = currentColsSize; i <= maximumCols; i++) {
-                this.layoutRow.addCol(i - 1);
+            for (var i = 0; i < maximumCols; i++) {
+                this.layoutRow.addCol(i);
             }
 
             Assert.areEqual(maximumCols, this.layoutRow.get('cols').length);
@@ -274,11 +274,11 @@ YUI.add('aui-layout-row-tests', function(Y) {
 
         'should be able to add a col without passing index': function() {
             var childNumber,
-                row = this.layoutRow,
                 col = new Y.LayoutCol({
                     size: 1,
                     value: {content: 'foo'}
-                });
+                }),
+                row = this.layoutRow;
 
             childNumber = row.get('cols').length;
             Assert.areEqual(childNumber, 3);
@@ -289,7 +289,7 @@ YUI.add('aui-layout-row-tests', function(Y) {
             Assert.areEqual(childNumber, 4);
         },
 
-        'should be able to add a col passing a index up than 11': function() {
+        'should be able to add a col passing a index greater than 11': function() {
             var childNumber,
                 row = this.layoutRow;
 
@@ -304,10 +304,10 @@ YUI.add('aui-layout-row-tests', function(Y) {
 
         'should be able to add a col between neighbors': function() {
             var childNumber,
-                row = this.layoutRow,
                 newCol = new Y.LayoutCol({
                     size: 1
-                });
+                }),
+                row = this.layoutRow;
 
             childNumber = row.get('cols').length;
             Assert.areEqual(childNumber, 3);
@@ -320,10 +320,10 @@ YUI.add('aui-layout-row-tests', function(Y) {
         },
 
         'should remove a col between neighbors': function() {
-            var layoutRow,
-                cols;
+            var cols,
+                layoutRow;
 
-            this._createLayoutBuilder( {
+            this._createLayoutCol( {
                 cols: [
                     new Y.LayoutCol({
                         size: 1,

--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1929](https://issues.liferay.com/browse/AUI-1929) Alloy Scheduler does not add long events to each day the event occurs on in Agenda view.
 * [AUI-1920](https://issues.liferay.com/browse/AUI-1920) Calendar - Hiding calendar does not update neither events nor "Show n more" link
 * [AUI-1893](https://issues.liferay.com/browse/AUI-1893) Wrong display of recurrent overnight events in week view in the last day of first week under DST
 * [AUI-1880](https://issues.liferay.com/browse/AUI-1880) Overlapping events don't show up correctly

--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1920](https://issues.liferay.com/browse/AUI-1920) Calendar - Hiding calendar does not update neither events nor "Show n more" link
 * [AUI-1893](https://issues.liferay.com/browse/AUI-1893) Wrong display of recurrent overnight events in week view in the last day of first week under DST
 * [AUI-1880](https://issues.liferay.com/browse/AUI-1880) Overlapping events don't show up correctly
 * [AUI-1871](https://issues.liferay.com/browse/AUI-1871) In month view, popover does not update values if an event was previously displayed

--- a/src/aui-scheduler/js/aui-scheduler-view-agenda.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-agenda.js
@@ -425,7 +425,7 @@ var SchedulerAgendaView = A.Component.create({
                                         color: schedulerEvent.get('color'),
                                         content: schedulerEvent.get('content'),
                                         dates: eventsDateFormatter.call(instance, startDate, endDate),
-                                        eventClassName: (startDate.getTime() < today.getTime()) ?
+                                        eventClassName: ((date.getTime() < today.getTime()) || (endDate.getTime() < today.getTime())) ?
                                             CSS_EVENT_PAST : '',
                                         firstClassName: (seIndex === 0) ? CSS_EVENT_FIRST : '',
                                         lastClassName: (seIndex === schedulerEventsLength - 1) ? CSS_EVENT_LAST : ''

--- a/src/aui-scheduler/js/aui-scheduler-view-agenda.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-agenda.js
@@ -471,8 +471,8 @@ var SchedulerAgendaView = A.Component.create({
 
             scheduler.eachEvent(
                 function(schedulerEvent) {
-                    var startDate = schedulerEvent.get('startDate'),
-                        endDate = schedulerEvent.get('endDate'),
+                    var endDate = schedulerEvent.get('endDate'),
+                        startDate = schedulerEvent.get('startDate'),
                         visible = schedulerEvent.get('visible'),
                         dayTS;
 

--- a/src/aui-scheduler/js/aui-scheduler-view-agenda.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-agenda.js
@@ -472,22 +472,29 @@ var SchedulerAgendaView = A.Component.create({
             scheduler.eachEvent(
                 function(schedulerEvent) {
                     var startDate = schedulerEvent.get('startDate'),
+			endDate = schedulerEvent.get('endDate'),
                         visible = schedulerEvent.get('visible'),
                         dayTS;
 
-                    if (!visible ||
-                        (startDate.getTime() < viewDate.getTime())) {
-
+                    if (!visible) {
                         return;
                     }
 
-                    dayTS = DateMath.safeClearTime(startDate).getTime();
+                    var displayDate = startDate;
 
-                    if (!eventsMap[dayTS]) {
-                        eventsMap[dayTS] = [];
+                    while (displayDate.getTime() <= endDate.getTime()) {
+                        if (displayDate.getTime() >= viewDate.getTime()) {
+                            dayTS = DateMath.safeClearTime(displayDate).getTime();
+
+                            if (!eventsMap[dayTS]) {
+                                eventsMap[dayTS] = [];
+                            }
+
+                            eventsMap[dayTS].push(schedulerEvent);
+                        }
+
+                        displayDate = DateMath.add(displayDate, DateMath.DAY, 1);
                     }
-
-                    eventsMap[dayTS].push(schedulerEvent);
                 }
             );
 

--- a/src/aui-scheduler/js/aui-scheduler-view-agenda.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-agenda.js
@@ -472,7 +472,7 @@ var SchedulerAgendaView = A.Component.create({
             scheduler.eachEvent(
                 function(schedulerEvent) {
                     var startDate = schedulerEvent.get('startDate'),
-			endDate = schedulerEvent.get('endDate'),
+                        endDate = schedulerEvent.get('endDate'),
                         visible = schedulerEvent.get('visible'),
                         dayTS;
 

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -420,16 +420,12 @@ var SchedulerTableView = A.Component.create({
                     events = [];
                 }
 
-                var visibleEvents = [];
-                var j = 0;
-                for (i = 0; i < events.length; i++) { 
-                	if (events[i].get('visible')) {
-                		visibleEvents[j] = events[i];
-                		j++;
-                	}
+                for (i = 0; i < events.length; i++) {
+                    if (!events[i].get('visible')) {
+                        events.splice(i, 1);
+                    }
                 }
-                events = visibleEvents;
-                
+
                 var evt = instance._getRenderableEvent(events, rowStartDate, rowEndDate, celDate);
 
                 var evtColNode = A.Node.create(TPL_SVT_TABLE_DATA_COL);

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -420,6 +420,16 @@ var SchedulerTableView = A.Component.create({
                     events = [];
                 }
 
+                var visibleEvents = [];
+                var j = 0;
+                for (i = 0; i < events.length; i++) { 
+                	if (events[i].get('visible')) {
+                		visibleEvents[j] = events[i];
+                		j++;
+                	}
+                }
+                events = visibleEvents;
+                
                 var evt = instance._getRenderableEvent(events, rowStartDate, rowEndDate, celDate);
 
                 var evtColNode = A.Node.create(TPL_SVT_TABLE_DATA_COL);

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -420,11 +420,9 @@ var SchedulerTableView = A.Component.create({
                     events = [];
                 }
 
-                for (i = 0; i < events.length; i++) {
-                    if (!events[i].get('visible')) {
-                        events.splice(i, 1);
-                    }
-                }
+                events = events.filter(function(currEvent) {
+                    return currEvent.get('visible');
+                });
 
                 var evt = instance._getRenderableEvent(events, rowStartDate, rowEndDate, celDate);
 


### PR DESCRIPTION
Hi,

It is compatible with the previous version, meaning that the configuration object can be the same.
Now there are three type of options field:
array where every element is a value
array where every element is an object of {'name':name, 'value':value} pairs (this is the new version)
object width value:name fields.

This trick is in the _setOptions function.

On master, there is no relationship with the formbuilder (as I see, formbuilder is very different now from 2.5) but we will have trouble when backporting this, because liferay's AUI version formbuilder is dependent from this fix. I will do the backport if you think this fix is OK.

Thanks
Péter